### PR TITLE
fix: handle illegal filename characters on Windows

### DIFF
--- a/download.go
+++ b/download.go
@@ -186,14 +186,26 @@ func downloadSubs(url string) string {
 }
 
 func downloadEpisode(contentId string, videoQuality, audioQuality, subtitlesLang *string, info EpisodeInfo) {
-	renamed := strings.ReplaceAll(info.EpisodeMetadata.SeriesTitle, "'", "_")
-	renamed = strings.ReplaceAll(renamed, "/", "_")
-	renamed = strings.ReplaceAll(renamed, ":", "_")
-	if _, err := os.Stat(renamed); err != nil {
-		_ = os.MkdirAll(renamed, 0777)
+	sanitize := func(s string) string {
+		illegal := []string{"\\", "/", ":", "*", "?", "\"", "<", ">", "|"}
+		res := s
+		for _, char := range illegal {
+			res = strings.ReplaceAll(res, char, "_")
+		}
+		return strings.TrimRight(res, " .")
 	}
+
+	cleanSeriesTitle := sanitize(info.EpisodeMetadata.SeriesTitle)
+
+	if _, err := os.Stat(cleanSeriesTitle); err != nil {
+		_ = os.MkdirAll(cleanSeriesTitle, 0777)
+	}
+
 	outputFile := fmt.Sprintf("%s/%s S%02vE%02v [%s].mkv",
-		renamed, info.EpisodeMetadata.SeriesTitle, info.EpisodeMetadata.SeasonNumber, info.EpisodeMetadata.EpisodeNumber,
+		cleanSeriesTitle,
+		cleanSeriesTitle,
+		info.EpisodeMetadata.SeasonNumber, 
+		info.EpisodeMetadata.EpisodeNumber,
 		*videoQuality,
 	)
 


### PR DESCRIPTION
**Title**: fix: handle illegal filename characters on Windows

**Description**: 

Summary
----------------
This Pull Request introduces a sanitization layer for output filenames and directory paths to ensure compatibility with Windows file systems. It also incorporates the parallel download logic from @igoreira0 to provide a more stable and high-performance base for these fixes.

The specific fix addresses the panic and path not found errors occurring when a series title or episode name contains characters reserved by Windows (such as :, ?, *, etc.).

Test plan
----------------
* [x] **Verified on Windows**: Successfully downloaded and merged:
* **Input**: `.\crunchyroll-downloader.exe -etp-rt XXX -url https://www.crunchyroll.com/watch/GMKUX4WP7/a-deep-sorrow-from-the-past`
* **Output**: `.\Wandering Witch_ The Journey of Elaina\Wandering Witch_ The Journey of Elaina S01E09 [1080p].mkv`


