### PR TITLE
Add --cc-lang flag to download closed caption (dubtitles) if they are available

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Usage of ./crunchyroll-downloader:
         Season number. Not used if an episode link is entered
   -subs-lang string
         Subtitle language(s), comma-separated for multiple (e.g. "en-US,es-419"). First is the default track (default "en-US")
+  -cc-lang string
+        Closed caption language(s), comma-separated for multiple. Downloaded in addition to -subs-lang, not instead of it
   -url string
         URL of the episode/season to download
   -file string

--- a/download.go
+++ b/download.go
@@ -190,21 +190,7 @@ func downloadSubs(url, format string) string {
 	return filename
 }
 
-// resolveSubtitle picks either the closed-caption or the regular subtitle
-// entry for a locale, depending on useCC and what's available.
-func resolveSubtitle(episode Episode, locale string, useCC bool) *Subtitle {
-	if useCC {
-		if cc, ok := episode.Captions[locale]; ok && cc != nil && cc.URL != "" {
-			return cc
-		}
-	}
-	if sub, ok := episode.Subtitles[locale]; ok && sub != nil && sub.URL != "" {
-		return sub
-	}
-	return nil
-}
-
-func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLangs []string, videoQuality, audioQuality *string, useCC bool) {
+func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLangs, ccLangs []string, videoQuality, audioQuality *string) {
 	sanitize := func(s string) string {
 		if s == "" {
 			return "Unknown"
@@ -300,33 +286,41 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 	}()
 
 	// Fetch the first version's playback first so we can validate subtitle
-	// availability before downloading anything heavy.
+	// and caption availability before downloading anything heavy.
 	firstEpisode := getEpisode(versions[0].contentId)
 	activeStreams[versions[0].contentId] = firstEpisode.Token
 
 	if len(subsLangs) == 1 && subsLangs[0] == "all" {
-		seen := map[string]bool{}
-		subsLangs = make([]string, 0, len(firstEpisode.Subtitles)+len(firstEpisode.Captions))
+		subsLangs = make([]string, 0, len(firstEpisode.Subtitles))
 		for locale, sub := range firstEpisode.Subtitles {
-			if sub != nil && sub.URL != "" && !seen[locale] {
+			if sub != nil && sub.URL != "" {
 				subsLangs = append(subsLangs, locale)
-				seen[locale] = true
-			}
-		}
-		for locale, cc := range firstEpisode.Captions {
-			if cc != nil && cc.URL != "" && !seen[locale] {
-				subsLangs = append(subsLangs, locale)
-				seen[locale] = true
 			}
 		}
 		sort.Strings(subsLangs)
 	}
+	if len(ccLangs) == 1 && ccLangs[0] == "all" {
+		ccLangs = make([]string, 0, len(firstEpisode.Captions))
+		for locale, cc := range firstEpisode.Captions {
+			if cc != nil && cc.URL != "" {
+				ccLangs = append(ccLangs, locale)
+			}
+		}
+		sort.Strings(ccLangs)
+	}
 
-	fmt.Printf("Audio locales: %s | Subtitle locales: %s\n", strings.Join(audioLangs, ", "), strings.Join(subsLangs, ", "))
+	fmt.Printf("Audio locales: %s | Subtitle locales: %s | CC locales: %s\n",
+		strings.Join(audioLangs, ", "), strings.Join(subsLangs, ", "), strings.Join(ccLangs, ", "))
 
 	for _, locale := range subsLangs {
-		if resolveSubtitle(firstEpisode, locale, useCC) == nil {
+		if firstEpisode.Subtitles[locale] == nil {
 			fmt.Printf("! Subtitle locale %s is not available for episode %v, aborting this episode.\n", locale, info.EpisodeMetadata.EpisodeNumber)
+			return
+		}
+	}
+	for _, locale := range ccLangs {
+		if firstEpisode.Captions[locale] == nil {
+			fmt.Printf("! Closed caption locale %s is not available for episode %v, aborting this episode.\n", locale, info.EpisodeMetadata.EpisodeNumber)
 			return
 		}
 	}
@@ -334,11 +328,21 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 	var subTracks []mediaTrack
 	for _, locale := range subsLangs {
 		fmt.Printf("Downloading subtitles for %s...\n", trackTitle(locale))
-		sub := resolveSubtitle(firstEpisode, locale, useCC)
+		sub := firstEpisode.Subtitles[locale]
 		subTracks = append(subTracks, mediaTrack{
 			file:   downloadSubs(sub.URL, sub.Format),
 			locale: locale,
 			format: sub.Format,
+		})
+	}
+	for _, locale := range ccLangs {
+		fmt.Printf("Downloading closed captions for %s...\n", trackTitle(locale))
+		cc := firstEpisode.Captions[locale]
+		subTracks = append(subTracks, mediaTrack{
+			file:   downloadSubs(cc.URL, cc.Format),
+			locale: locale,
+			format: cc.Format,
+			isCC:   true,
 		})
 	}
 	if len(subTracks) > 0 {
@@ -402,7 +406,7 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 	mergeEverything(videoFile, audioTracks, subTracks, outputFile, info)
 }
 
-func downloadSeason(videoQuality, audioQuality *string, audioLangs, subsLangs []string, episodes []SeasonEpisode, useCC bool) {
+func downloadSeason(videoQuality, audioQuality *string, audioLangs, subsLangs, ccLangs []string, episodes []SeasonEpisode) {
 	fmt.Printf("Downloading season %v of %s (%v episodes)\n\n", episodes[0].SeasonNumber, episodes[0].SeriesTitle, len(episodes))
 
 	for _, episode := range episodes {
@@ -418,6 +422,6 @@ func downloadSeason(videoQuality, audioQuality *string, audioLangs, subsLangs []
 			Title: episode.Title,
 		}
 
-		downloadEpisode(episode.ID, info, audioLangs, subsLangs, videoQuality, audioQuality, useCC)
+		downloadEpisode(episode.ID, info, audioLangs, subsLangs, ccLangs, videoQuality, audioQuality)
 	}
 }

--- a/download.go
+++ b/download.go
@@ -69,9 +69,12 @@ func downloadPart(url string) ([]byte, error) {
 	return nil, fmt.Errorf("failed after %d retries", maxRetries)
 }
 
-func getFilename(set *mpd.AdaptationSet) string {
+func getFilename(set *mpd.AdaptationSet, subExt string) string {
 	if set == nil {
-		f, _ := os.CreateTemp("", "crdl-subs-*.ass")
+		if subExt == "" {
+			subExt = "ass"
+		}
+		f, _ := os.CreateTemp("", "crdl-subs-*."+subExt)
 		return f.Name()
 	}
 	for _, representation := range set.Representations {
@@ -144,7 +147,7 @@ func downloadParts(baseUrl, representationId *string, set *mpd.AdaptationSet) (s
 		parts = append(parts, data...)
 	}
 
-	filename := getFilename(set)
+	filename := getFilename(set, "")
 	file, err := os.Create(filename)
 	if err != nil {
 		return "", err
@@ -157,7 +160,7 @@ func downloadParts(baseUrl, representationId *string, set *mpd.AdaptationSet) (s
 	return filename, nil
 }
 
-func downloadSubs(url string) string {
+func downloadSubs(url, format string) string {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		panic(err)
@@ -176,7 +179,7 @@ func downloadSubs(url string) string {
 		panic(err)
 	}
 
-	filename := getFilename(nil)
+	filename := getFilename(nil, format)
 	file, err := os.Create(filename)
 	if err != nil {
 		panic(err)
@@ -187,7 +190,21 @@ func downloadSubs(url string) string {
 	return filename
 }
 
-func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLangs []string, videoQuality, audioQuality *string) {
+// resolveSubtitle picks either the closed-caption or the regular subtitle
+// entry for a locale, depending on useCC and what's available.
+func resolveSubtitle(episode Episode, locale string, useCC bool) *Subtitle {
+	if useCC {
+		if cc, ok := episode.Captions[locale]; ok && cc != nil && cc.URL != "" {
+			return cc
+		}
+	}
+	if sub, ok := episode.Subtitles[locale]; ok && sub != nil && sub.URL != "" {
+		return sub
+	}
+	return nil
+}
+
+func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLangs []string, videoQuality, audioQuality *string, useCC bool) {
 	sanitize := func(s string) string {
 		if s == "" {
 			return "Unknown"
@@ -288,10 +305,18 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 	activeStreams[versions[0].contentId] = firstEpisode.Token
 
 	if len(subsLangs) == 1 && subsLangs[0] == "all" {
-		subsLangs = make([]string, 0, len(firstEpisode.Subtitles))
+		seen := map[string]bool{}
+		subsLangs = make([]string, 0, len(firstEpisode.Subtitles)+len(firstEpisode.Captions))
 		for locale, sub := range firstEpisode.Subtitles {
-			if sub != nil && sub.URL != "" {
+			if sub != nil && sub.URL != "" && !seen[locale] {
 				subsLangs = append(subsLangs, locale)
+				seen[locale] = true
+			}
+		}
+		for locale, cc := range firstEpisode.Captions {
+			if cc != nil && cc.URL != "" && !seen[locale] {
+				subsLangs = append(subsLangs, locale)
+				seen[locale] = true
 			}
 		}
 		sort.Strings(subsLangs)
@@ -300,7 +325,7 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 	fmt.Printf("Audio locales: %s | Subtitle locales: %s\n", strings.Join(audioLangs, ", "), strings.Join(subsLangs, ", "))
 
 	for _, locale := range subsLangs {
-		if firstEpisode.Subtitles[locale] == nil {
+		if resolveSubtitle(firstEpisode, locale, useCC) == nil {
 			fmt.Printf("! Subtitle locale %s is not available for episode %v, aborting this episode.\n", locale, info.EpisodeMetadata.EpisodeNumber)
 			return
 		}
@@ -309,7 +334,12 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 	var subTracks []mediaTrack
 	for _, locale := range subsLangs {
 		fmt.Printf("Downloading subtitles for %s...\n", trackTitle(locale))
-		subTracks = append(subTracks, mediaTrack{file: downloadSubs(firstEpisode.Subtitles[locale].URL), locale: locale})
+		sub := resolveSubtitle(firstEpisode, locale, useCC)
+		subTracks = append(subTracks, mediaTrack{
+			file:   downloadSubs(sub.URL, sub.Format),
+			locale: locale,
+			format: sub.Format,
+		})
 	}
 	if len(subTracks) > 0 {
 		fmt.Println("Downloaded subtitles!")
@@ -372,7 +402,7 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 	mergeEverything(videoFile, audioTracks, subTracks, outputFile, info)
 }
 
-func downloadSeason(videoQuality, audioQuality *string, audioLangs, subsLangs []string, episodes []SeasonEpisode) {
+func downloadSeason(videoQuality, audioQuality *string, audioLangs, subsLangs []string, episodes []SeasonEpisode, useCC bool) {
 	fmt.Printf("Downloading season %v of %s (%v episodes)\n\n", episodes[0].SeasonNumber, episodes[0].SeriesTitle, len(episodes))
 
 	for _, episode := range episodes {
@@ -388,6 +418,6 @@ func downloadSeason(videoQuality, audioQuality *string, audioLangs, subsLangs []
 			Title: episode.Title,
 		}
 
-		downloadEpisode(episode.ID, info, audioLangs, subsLangs, videoQuality, audioQuality)
+		downloadEpisode(episode.ID, info, audioLangs, subsLangs, videoQuality, audioQuality, useCC)
 	}
 }

--- a/episode.go
+++ b/episode.go
@@ -11,8 +11,10 @@ import (
 type Episode struct {
 	// Dash manifest file URL
 	ManifestURL string `json:"url"`
-	// List of .ass files
+	// List of .ass files (translation-style subtitles)
 	Subtitles map[string]*Subtitle `json:"subtitles"`
+	// List of .vtt files (closed captions, transcribing the dub audio)
+	Captions map[string]*Subtitle `json:"captions"`
 	// Token to give to the Widevine CDM challenge
 	Token string `json:"token"`
 	// Error, `nil` if there's no error
@@ -22,7 +24,9 @@ type Episode struct {
 type Subtitle struct {
 	// Language represents a subtitle language in the "en-US" format
 	Language string `json:"language"`
-	// Direct URL to the .ass file
+	// Format of the file, e.g. "ass" or "vtt"
+	Format string `json:"format"`
+	// Direct URL to the subtitle/caption file
 	URL string `json:"url"`
 }
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var (
 	seasonNumber  = flag.Int("season", 0, "Season number. Not used if an episode link is entered")
 	etpRt         = flag.String("etp-rt", "", "The \"etp_rt\" cookie value of your account")
 	debug         = flag.Bool("debug-manifest", false, "Log raw episode playback JSON and manifest XML")
+	useCC         = flag.Bool("use-cc", false, "Prefer closed captions over regular subtitles for locales where both are available")
 )
 
 // parseLangs splits a comma-separated locale list, trimming spaces and dropping
@@ -60,7 +61,7 @@ func processUrl(url string) {
 
 	if contentType == "watch" {
 		info := getEpisodeInfo(contentId)
-		downloadEpisode(contentId, info, audioLangs, subsLangs, videoQuality, audioQuality)
+		downloadEpisode(contentId, info, audioLangs, subsLangs, videoQuality, audioQuality, *useCC)
 	} else {
 		seasons := getSeasons(contentId, primaryAudio, primarySubs)
 
@@ -78,13 +79,13 @@ func processUrl(url string) {
 			}
 
 			episodes := getSeasonEpisodes(seasonId, primaryAudio, primarySubs)
-			downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, episodes)
+			downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, episodes, *useCC)
 		} else {
 			print("No season number specified, downloading all seasons...\n")
 
 			for _, season := range seasons {
 				episodes := getSeasonEpisodes(season.ID, primaryAudio, primarySubs)
-				downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, episodes)
+				downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, episodes, *useCC)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -12,12 +12,12 @@ var (
 	token         = ""
 	audioLang     = flag.String("audio-lang", "ja-JP", "Audio language(s), comma-separated for multiple (e.g. \"ja-JP,en-US\"). First is the default track")
 	subtitlesLang = flag.String("subs-lang", "en-US", "Subtitle language(s), comma-separated for multiple (e.g. \"en-US,es-419\"). First is the default track")
+	ccLang        = flag.String("cc-lang", "", "Closed caption language(s), comma-separated for multiple (e.g. \"en-US\"). Downloaded in addition to --subs-lang, not instead of it")
 	videoQuality  = flag.String("video-quality", "1080p", "Video quality")
 	audioQuality  = flag.String("audio-quality", "192k", "Audio quality")
 	seasonNumber  = flag.Int("season", 0, "Season number. Not used if an episode link is entered")
 	etpRt         = flag.String("etp-rt", "", "The \"etp_rt\" cookie value of your account")
 	debug         = flag.Bool("debug-manifest", false, "Log raw episode playback JSON and manifest XML")
-	useCC         = flag.Bool("use-cc", false, "Prefer closed captions over regular subtitles for locales where both are available")
 )
 
 // parseLangs splits a comma-separated locale list, trimming spaces and dropping
@@ -49,6 +49,7 @@ func processUrl(url string) {
 		audioLangs = []string{"ja-JP"}
 	}
 	subsLangs := parseLangs(*subtitlesLang)
+	ccLangs := parseLangs(*ccLang)
 
 	// The season/series API endpoints take a single preferred locale; use the
 	// primary (first) requested one. All dub versions are still listed per
@@ -61,7 +62,7 @@ func processUrl(url string) {
 
 	if contentType == "watch" {
 		info := getEpisodeInfo(contentId)
-		downloadEpisode(contentId, info, audioLangs, subsLangs, videoQuality, audioQuality, *useCC)
+		downloadEpisode(contentId, info, audioLangs, subsLangs, ccLangs, videoQuality, audioQuality)
 	} else {
 		seasons := getSeasons(contentId, primaryAudio, primarySubs)
 
@@ -79,13 +80,13 @@ func processUrl(url string) {
 			}
 
 			episodes := getSeasonEpisodes(seasonId, primaryAudio, primarySubs)
-			downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, episodes, *useCC)
+			downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, ccLangs, episodes)
 		} else {
 			print("No season number specified, downloading all seasons...\n")
 
 			for _, season := range seasons {
 				episodes := getSeasonEpisodes(season.ID, primaryAudio, primarySubs)
-				downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, episodes, *useCC)
+				downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, ccLangs, episodes)
 			}
 		}
 	}

--- a/output.go
+++ b/output.go
@@ -11,6 +11,7 @@ import (
 type mediaTrack struct {
 	file   string
 	locale string
+	format string // subtitle source format, e.g. "ass" or "vtt". Unused for audio tracks.
 }
 
 // trackTitle returns a human-readable track name for a locale, falling back to
@@ -44,8 +45,17 @@ func mergeEverything(videoFile string, audioTracks, subTracks []mediaTrack, outp
 	}
 
 	args = append(args, "-c:v", "copy", "-c:a", "copy")
-	if len(subTracks) > 0 {
-		args = append(args, "-c:s", "copy")
+	// WebVTT cue-positioning metadata (e.g. "line:90% align:center") isn't
+	// rendered correctly by most players when copied as-is into an MKV, so
+	// VTT subtitle tracks are transcoded to SRT (which has no positioning
+	// syntax) instead of stream-copied. ASS tracks keep "copy" to preserve
+	// their styling.
+	for j, sub := range subTracks {
+		if sub.format == "vtt" {
+			args = append(args, fmt.Sprintf("-c:s:%d", j), "srt")
+		} else {
+			args = append(args, fmt.Sprintf("-c:s:%d", j), "copy")
+		}
 	}
 
 	for i, audio := range audioTracks {

--- a/output.go
+++ b/output.go
@@ -12,6 +12,7 @@ type mediaTrack struct {
 	file   string
 	locale string
 	format string // subtitle source format, e.g. "ass" or "vtt". Unused for audio tracks.
+	isCC   bool   // true if this track is a closed caption rather than a regular subtitle
 }
 
 // trackTitle returns a human-readable track name for a locale, falling back to
@@ -47,9 +48,9 @@ func mergeEverything(videoFile string, audioTracks, subTracks []mediaTrack, outp
 	args = append(args, "-c:v", "copy", "-c:a", "copy")
 	// WebVTT cue-positioning metadata (e.g. "line:90% align:center") isn't
 	// rendered correctly by most players when copied as-is into an MKV, so
-	// VTT subtitle tracks are transcoded to SRT (which has no positioning
-	// syntax) instead of stream-copied. ASS tracks keep "copy" to preserve
-	// their styling.
+	// VTT subtitle/caption tracks are transcoded to SRT (which has no
+	// positioning syntax) instead of stream-copied. ASS tracks keep "copy"
+	// to preserve their styling.
 	for j, sub := range subTracks {
 		if sub.format == "vtt" {
 			args = append(args, fmt.Sprintf("-c:s:%d", j), "srt")
@@ -65,16 +66,20 @@ func mergeEverything(videoFile string, audioTracks, subTracks []mediaTrack, outp
 		)
 	}
 	for j, sub := range subTracks {
+		title := trackTitle(sub.locale)
+		if sub.isCC {
+			title += " [CC]"
+		}
 		args = append(args,
 			fmt.Sprintf("-metadata:s:s:%d", j), "language="+languageCodes[sub.locale],
-			fmt.Sprintf("-metadata:s:s:%d", j), "title="+trackTitle(sub.locale),
+			fmt.Sprintf("-metadata:s:s:%d", j), "title="+title,
 		)
 	}
-
-	// Mark only the first audio/subtitle track (the primary requested locale) as
+	// Mark only the first audio track and the first non-CC subtitle track as
 	// default. Disposition must be set on every track: each downloaded audio
 	// file is a standalone default stream, so the non-primary ones must be
-	// explicitly cleared.
+	// explicitly cleared. Closed captions are never marked default; they're
+	// an opt-in extra a viewer toggles deliberately.
 	for i := range audioTracks {
 		disposition := "0"
 		if i == 0 {
@@ -82,10 +87,12 @@ func mergeEverything(videoFile string, audioTracks, subTracks []mediaTrack, outp
 		}
 		args = append(args, fmt.Sprintf("-disposition:a:%d", i), disposition)
 	}
-	for j := range subTracks {
+	defaultSubSet := false
+	for j, sub := range subTracks {
 		disposition := "0"
-		if j == 0 {
+		if !sub.isCC && !defaultSubSet {
 			disposition = "default"
+			defaultSubSet = true
 		}
 		args = append(args, fmt.Sprintf("-disposition:s:%d", j), disposition)
 	}


### PR DESCRIPTION
Example use getting both subtitles and closed captions:  
`crunchyroll-downloader.exe --audio-lang "en-US,ja-JP" --subs-lang "en-US" --cc-lang "en-US" --video-quality "360p" --etp-rt "[insert]" --url "https://www.crunchyroll.com/watch/GE00258180ENUS/the-magic-that-started-everything"`

Full disclosure I used Claude AI for this change, so close this if you have issues with that.