### PR TITLE
Complete truthful bounded subtitle indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,15 @@ client_id.bin
 private_key.pem
 
 *.mkv
+
+# Credentials — never commit
+etp_rt.txt
+.env
+crunchyroll-downloader
+*_index.json
+
+crunchyroll-downloader.m*
+crunchyroll-downloader.media*
+*_index*.json
+*_indexer_*.log
+One Piece_subs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Guide — Crunchyroll Downloader
 
-This document describes how to reproduce the full download workflow: clone, install dependencies, obtain a Widevine CDM, authenticate, download + decrypt an episode, and clip the result. Written for macOS (Apple Silicon) but the steps generalize to Linux/Windows.
+This document describes the subtitle-indexing and full-media workflows. Subtitle-only indexing does not require a Widevine device. Full-media downloads require an operator-owned, lawfully provisioned Widevine credential. Written for macOS (Apple Silicon), but the steps generalize to Linux/Windows.
 
 ---
 
@@ -25,7 +25,7 @@ Downloads DRM-protected anime from Crunchyroll and outputs a decrypted `.mkv` fi
 | [Go](https://go.dev/dl/) 1.25+ | `brew install go` |
 | [FFmpeg](https://ffmpeg.org) | `brew install ffmpeg` |
 | Crunchyroll Premium account | — (needed for premium-only content) |
-| Widevine CDM (`.wvd` file) | See §4 below |
+| Widevine CDM (`.wvd` file) | Full-media workflow only; see §4 below |
 
 Verify:
 ```bash
@@ -47,29 +47,30 @@ go build .
 
 ## 4. Widevine CDM (`.wvd` file)
 
-Crunchyroll streams are DRM-protected. You need a Widevine L3 CDM to obtain decryption keys. The downloader looks for **one** of these in the current directory (`drm.go:76`–`getWidevineDevice`):
+Crunchyroll streams are DRM-protected. Full-media operation needs a Widevine L3 credential to obtain decryption keys. The downloader reads credentials only from explicit private-file environment variables (`drm.go`–`getWidevineDevice`):
 
-- A `.wvd` file (Widevine Device v2 format) — **preferred, single file**
-- Or both `client_id.bin` and `private_key.pem`
+- `CRUNCHYROLL_WIDEVINE_DEVICE_FILE=/private/path/device.wvd` — **preferred, single file**
+- Or both `CRUNCHYROLL_WIDEVINE_CLIENT_ID_FILE` and `CRUNCHYROLL_WIDEVINE_PRIVATE_KEY_FILE`
 
-### Where to get a CDM
+Each path must resolve directly to a regular mode-`0600` file outside the repository; symlinks and broader modes fail closed. The downloader no longer scans the working tree for device credentials.
 
-These are leaked/extracted L3 device credentials from Android emulators. Common sources:
-- VideoHelp forum: "Ready to use CDMs" thread
-- Search "ready to use cdms" on Google
+### Credential provenance
+
+Use only a Widevine credential that the operator lawfully owns or is authorized to use. Never obtain, recommend, or use leaked, extracted, shared, or third-party device credentials. Subtitle-only indexing does not load a CDM and must not be blocked on one.
 
 ### How to place it
 
-Copy **one** `.wvd` file into the repo folder:
+Keep the credential outside the repository in operator-private storage with mode `0600`, then select it by path without copying it into the working tree:
 ```bash
-cp /path/to/your.wvd .
+install -m 0600 /path/to/operator-owned.wvd ~/.config/crunchyroll-downloader/device.wvd
+export CRUNCHYROLL_WIDEVINE_DEVICE_FILE="$HOME/.config/crunchyroll-downloader/device.wvd"
 ```
 
-The downloader uses the **first** `.wvd` it finds in the working directory (`drm.go:79`–`87`). Having multiple files there is fine but only one is used — the one that sorts first alphabetically.
+The downloader never scans its working directory for a device. Keep the configured path in operator-owned runtime configuration and do not copy the credential into the repository.
 
 ### CDMs get revoked
 
-L3 CDMs are periodically revoked by Google/Widevine. A revoked CDM will still **load** fine but will fail at license time. If you see a license error at runtime (`drm.go:336`), swap in a different `.wvd`.
+An operator-owned device can become unusable or revoked. A device may still **load** but fail at license time. If that happens, stop the full-media workflow and have the operator provision another authorized device; do not search for shared credentials.
 
 ### Verifying a CDM (optional)
 
@@ -102,16 +103,16 @@ The downloader needs your Crunchyroll `etp_rt` cookie to authenticate.
 
 ### How to store it safely
 
-The `etp_rt` value is a secret. Save it to a gitignored file so it never gets committed:
+The `etp_rt` value is a secret. Save it outside the repository in an operator-private `0600` file:
 
 ```bash
-# The file etp_rt.txt is in .gitignore
-echo "YOUR_ETP_RT_VALUE_HERE" > etp_rt.txt
+install -d -m 0700 ~/.config/crunchyroll-downloader
+install -m 0600 /path/to/newly-provisioned-etp-rt ~/.config/crunchyroll-downloader/etp_rt.txt
 ```
 
-Then use it via shell substitution so the value doesn't appear in your shell history:
+Pass only the file path. Never put the value in argv, shell substitution, logs, receipts, prompts, fixtures, or Git:
 ```bash
-./crunchyroll-downloader --url "..." --etp-rt "$(cat etp_rt.txt)"
+./crunchyroll-downloader --url "..." --etp-rt-file ~/.config/crunchyroll-downloader/etp_rt.txt
 ```
 
 ### Token expiry
@@ -126,7 +127,7 @@ Access tokens expire. The downloader handles this automatically — `http_reques
 |---|---|---|
 | `-url` | — | URL of an episode (`/watch/...`) or series (`/series/...`) |
 | `-file` | — | Path to a text file with one URL per line (batch) |
-| `-etp-rt` | — | Your `etp_rt` cookie value (**required**) |
+| `-etp-rt-file` | — | Path to a regular `0600` file containing the `etp_rt` cookie (**required**) |
 | `-season` | `0` | Season number (only for `/series/` URLs; `0` = all seasons) |
 | `-audio-lang` | `ja-JP` | Audio language(s), comma-separated. First = default track. Use `all` for every available dub. |
 | `-subs-lang` | `en-US` | Subtitle language(s), comma-separated. First = default track. Use `all` for every available sub. |
@@ -140,43 +141,43 @@ Access tokens expire. The downloader handles this automatically — `http_reques
 # Single episode (Japanese audio + English subs)
 ./crunchyroll-downloader \
   --url "https://www.crunchyroll.com/watch/GE00350806JAJP/the-long-sought-elbaph-the-big-reunion-banquet" \
-  --etp-rt "$(cat etp_rt.txt)"
+  --etp-rt-file ~/.config/crunchyroll-downloader/etp_rt.txt
 
 # Entire season
 ./crunchyroll-downloader \
   --url "https://www.crunchyroll.com/series/GJ0H7Q5ZJ/hells-paradise" \
   --season 1 \
-  --etp-rt "$(cat etp_rt.txt)"
+  --etp-rt-file ~/.config/crunchyroll-downloader/etp_rt.txt
 
 # All seasons of a series
 ./crunchyroll-downloader \
   --url "https://www.crunchyroll.com/series/GJ0H7Q5ZJ/hells-paradise" \
-  --etp-rt "$(cat etp_rt.txt)"
+  --etp-rt-file ~/.config/crunchyroll-downloader/etp_rt.txt
 
 # English dub audio
 ./crunchyroll-downloader \
   --url "https://www.crunchyroll.com/watch/GE00350806JAJP/..." \
-  --etp-rt "$(cat etp_rt.txt)" \
+  --etp-rt-file ~/.config/crunchyroll-downloader/etp_rt.txt \
   --audio-lang en-US
 
 # Multiple audio + subtitle tracks in one file (first of each = default)
 ./crunchyroll-downloader \
   --url "https://www.crunchyroll.com/watch/GE00350806JAJP/..." \
-  --etp-rt "$(cat etp_rt.txt)" \
+  --etp-rt-file ~/.config/crunchyroll-downloader/etp_rt.txt \
   --audio-lang ja-JP,en-US \
   --subs-lang en-US,es-419,de-DE
 
 # Download ALL available dubs + ALL subtitles
 ./crunchyroll-downloader \
   --url "https://www.crunchyroll.com/watch/GE00350806JAJP/..." \
-  --etp-rt "$(cat etp_rt.txt)" \
+  --etp-rt-file ~/.config/crunchyroll-downloader/etp_rt.txt \
   --audio-lang all \
   --subs-lang all
 
 # Batch download from a file (one URL per line)
 ./crunchyroll-downloader \
   --file list.txt \
-  --etp-rt "$(cat etp_rt.txt)" \
+  --etp-rt-file ~/.config/crunchyroll-downloader/etp_rt.txt \
   --subs-lang en-US
 ```
 
@@ -188,7 +189,7 @@ Files are saved to `<SeriesTitle>/<SeriesTitle> S<SS>E<EE> - <EpisodeTitle> [<qu
 
 If a download fails or behaves unexpectedly, add `--debug-manifest` to see the raw API responses:
 ```bash
-./crunchyroll-downloader --url "..." --etp-rt "$(cat etp_rt.txt)" --debug-manifest
+./crunchyroll-downloader --url "..." --etp-rt-file ~/.config/crunchyroll-downloader/etp_rt.txt --debug-manifest
 ```
 
 ## 7. Available qualities
@@ -330,10 +331,10 @@ crunchyroll-downloader/
 ├── go.mod / go.sum      # Go dependencies
 ├── .gitignore           # Ignores *.wvd, *.mkv, etp_rt.txt, .env
 ├── cdm_test.go          # Optional test: verifies .wvd loads correctly
-├── etp_rt.txt           # Your cookie (gitignored — you create this)
-├── *.wvd                # Your CDM (gitignored — you provide this)
 └── crunchyroll-downloader  # Built binary
 ```
+
+Authentication and device files belong in private operator storage outside this tree; only their paths are configured at runtime.
 
 ### Key dependencies
 
@@ -348,8 +349,8 @@ crunchyroll-downloader/
 
 | Problem | Cause | Fix |
 |---|---|---|
-| `no widevine device provided` | No `.wvd` (or `client_id.bin` + `private_key.pem`) in the working directory | Copy a `.wvd` into the repo folder |
-| `getLicense` error / no keys | CDM is revoked | Swap in a different `.wvd` |
+| `no widevine device provided` | A full-media run has no explicit authorized device-file environment configuration | Provision an authorized device in private `0600` storage and set the documented file variable; subtitle-only indexing needs none |
+| `getLicense` error / no keys | The operator-owned device may be invalid or revoked | Stop and have the operator provision another authorized device |
 | `Access token expired` message | Normal — token auto-refreshes | Nothing; it retries automatically |
 | `Audio locale X is not available` | Episode doesn't have that dub | Remove it from `-audio-lang` or use `all` |
 | `Subtitle locale X is not available` | Episode doesn't have that sub | Remove it from `-subs-lang` or use `all` |
@@ -361,8 +362,9 @@ crunchyroll-downloader/
 
 ## 13. Security notes
 
-- **`etp_rt.txt` is gitignored** — never commit it. The `.gitignore` also blocks `*.wvd`, `*.mkv`, `client_id.bin`, `private_key.pem`, and `.env`.
+- Keep `etp_rt` and device credentials outside the repository in `0700` directories and `0600` regular files; ignore rules are defense in depth, not storage policy.
 - The `etp_rt` cookie grants access to your Crunchyroll account. Treat it like a password.
-- CDMs are leaked device credentials. They are not "yours" — they get revoked and you should not share them publicly.
+- Never pass a raw credential in argv or record it in logs, prompts, fixtures, receipts, or Git.
+- Use only operator-owned or lawfully provisioned Widevine credentials. Never use leaked, extracted, shared, or third-party device credentials.
 - The downloader authenticates as your account. Download only content you have legitimate access to.
 - Decrypted output files are DRM-free. Respect Crunchyroll's terms of service regarding offline copies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,368 @@
+# Agent Guide — Crunchyroll Downloader
+
+This document describes how to reproduce the full download workflow: clone, install dependencies, obtain a Widevine CDM, authenticate, download + decrypt an episode, and clip the result. Written for macOS (Apple Silicon) but the steps generalize to Linux/Windows.
+
+---
+
+## 1. What this tool does
+
+Downloads DRM-protected anime from Crunchyroll and outputs a decrypted `.mkv` file containing video (H.264), audio (AAC), and subtitles (ASS). The Widevine CDM is used **only at download time** to decrypt the stream — the output MKV is a plain, DRM-free file that plays in any player and can be clipped freely with no keys or CDM needed afterward.
+
+**Pipeline** (see `download.go:190`–`downloadEpisode`):
+1. Authenticate with the `etp_rt` cookie → get an access token (`token.go`)
+2. Fetch episode metadata + playback info (`episode.go`)
+3. Parse the DASH manifest (`mpd.go`)
+4. Load the `.wvd` CDM and obtain a Widevine license (`drm.go`)
+5. Download encrypted audio + video segments in parallel (10 workers)
+6. Decrypt segments using the license keys (`download.go:153`)
+7. Merge video + audio + subtitles into a single MKV via ffmpeg (`output.go`)
+8. Clean up temp files
+
+## 2. Requirements
+
+| Requirement | How to install (macOS) |
+|---|---|
+| [Go](https://go.dev/dl/) 1.25+ | `brew install go` |
+| [FFmpeg](https://ffmpeg.org) | `brew install ffmpeg` |
+| Crunchyroll Premium account | — (needed for premium-only content) |
+| Widevine CDM (`.wvd` file) | See §4 below |
+
+Verify:
+```bash
+go version      # expect go1.25+
+ffmpeg -version # expect 5.x+
+```
+
+## 3. Setup
+
+```bash
+# Clone the repo
+git clone https://github.com/CuteTenshii/crunchyroll-downloader.git
+cd crunchyroll-downloader
+
+# Build the binary
+go build .
+# → produces ./crunchyroll-downloader
+```
+
+## 4. Widevine CDM (`.wvd` file)
+
+Crunchyroll streams are DRM-protected. You need a Widevine L3 CDM to obtain decryption keys. The downloader looks for **one** of these in the current directory (`drm.go:76`–`getWidevineDevice`):
+
+- A `.wvd` file (Widevine Device v2 format) — **preferred, single file**
+- Or both `client_id.bin` and `private_key.pem`
+
+### Where to get a CDM
+
+These are leaked/extracted L3 device credentials from Android emulators. Common sources:
+- VideoHelp forum: "Ready to use CDMs" thread
+- Search "ready to use cdms" on Google
+
+### How to place it
+
+Copy **one** `.wvd` file into the repo folder:
+```bash
+cp /path/to/your.wvd .
+```
+
+The downloader uses the **first** `.wvd` it finds in the working directory (`drm.go:79`–`87`). Having multiple files there is fine but only one is used — the one that sorts first alphabetically.
+
+### CDMs get revoked
+
+L3 CDMs are periodically revoked by Google/Widevine. A revoked CDM will still **load** fine but will fail at license time. If you see a license error at runtime (`drm.go:336`), swap in a different `.wvd`.
+
+### Verifying a CDM (optional)
+
+A test file (`cdm_test.go`) is included that checks whether a `.wvd` parses correctly through the `gowidevine` library — verifying the RSA private key and DRM certificate are valid. This does **not** check revocation (only a live license request can do that):
+
+```bash
+go test -run TestLoadWVD -v
+```
+
+### Creating a `.wvd` from raw files (pywidevine)
+
+If you have `client_id.bin` and `private_key.pem` but want a single `.wvd`:
+```bash
+pip install pywidevine
+pywidevine create-device -k private_key.pem -c client_id.bin -t CHROME -l 3 -o .
+```
+However, **this is optional** — the Go downloader accepts the raw files directly.
+
+## 5. Authentication (`etp_rt` cookie)
+
+The downloader needs your Crunchyroll `etp_rt` cookie to authenticate.
+
+### How to get it
+
+1. Go to https://crunchyroll.com and log in
+2. Open Developer Tools (F12 or Ctrl+Shift+I)
+3. **Chrome/Edge**: Application → Cookies → crunchyroll.com
+   **Firefox**: Storage → Cookies → crunchyroll.com
+4. Find the cookie named `etp_rt` and copy its value
+
+### How to store it safely
+
+The `etp_rt` value is a secret. Save it to a gitignored file so it never gets committed:
+
+```bash
+# The file etp_rt.txt is in .gitignore
+echo "YOUR_ETP_RT_VALUE_HERE" > etp_rt.txt
+```
+
+Then use it via shell substitution so the value doesn't appear in your shell history:
+```bash
+./crunchyroll-downloader --url "..." --etp-rt "$(cat etp_rt.txt)"
+```
+
+### Token expiry
+
+Access tokens expire. The downloader handles this automatically — `http_request.go:13`–`19` detects a 401, refetches a token using the stored `etp_rt`, and retries. You don't need to do anything.
+
+## 6. Usage
+
+### Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `-url` | — | URL of an episode (`/watch/...`) or series (`/series/...`) |
+| `-file` | — | Path to a text file with one URL per line (batch) |
+| `-etp-rt` | — | Your `etp_rt` cookie value (**required**) |
+| `-season` | `0` | Season number (only for `/series/` URLs; `0` = all seasons) |
+| `-audio-lang` | `ja-JP` | Audio language(s), comma-separated. First = default track. Use `all` for every available dub. |
+| `-subs-lang` | `en-US` | Subtitle language(s), comma-separated. First = default track. Use `all` for every available sub. |
+| `-video-quality` | `1080p` | Video quality (see §7) |
+| `-audio-quality` | `192k` | Audio quality (see §7) |
+| `-debug-manifest` | `false` | Print raw playback JSON and manifest XML |
+
+### Examples
+
+```bash
+# Single episode (Japanese audio + English subs)
+./crunchyroll-downloader \
+  --url "https://www.crunchyroll.com/watch/GE00350806JAJP/the-long-sought-elbaph-the-big-reunion-banquet" \
+  --etp-rt "$(cat etp_rt.txt)"
+
+# Entire season
+./crunchyroll-downloader \
+  --url "https://www.crunchyroll.com/series/GJ0H7Q5ZJ/hells-paradise" \
+  --season 1 \
+  --etp-rt "$(cat etp_rt.txt)"
+
+# All seasons of a series
+./crunchyroll-downloader \
+  --url "https://www.crunchyroll.com/series/GJ0H7Q5ZJ/hells-paradise" \
+  --etp-rt "$(cat etp_rt.txt)"
+
+# English dub audio
+./crunchyroll-downloader \
+  --url "https://www.crunchyroll.com/watch/GE00350806JAJP/..." \
+  --etp-rt "$(cat etp_rt.txt)" \
+  --audio-lang en-US
+
+# Multiple audio + subtitle tracks in one file (first of each = default)
+./crunchyroll-downloader \
+  --url "https://www.crunchyroll.com/watch/GE00350806JAJP/..." \
+  --etp-rt "$(cat etp_rt.txt)" \
+  --audio-lang ja-JP,en-US \
+  --subs-lang en-US,es-419,de-DE
+
+# Download ALL available dubs + ALL subtitles
+./crunchyroll-downloader \
+  --url "https://www.crunchyroll.com/watch/GE00350806JAJP/..." \
+  --etp-rt "$(cat etp_rt.txt)" \
+  --audio-lang all \
+  --subs-lang all
+
+# Batch download from a file (one URL per line)
+./crunchyroll-downloader \
+  --file list.txt \
+  --etp-rt "$(cat etp_rt.txt)" \
+  --subs-lang en-US
+```
+
+### Output location
+
+Files are saved to `<SeriesTitle>/<SeriesTitle> S<SS>E<EE> - <EpisodeTitle> [<quality>].mkv` relative to the working directory. If the file already exists, the episode is skipped (`download.go:223`).
+
+### Debugging
+
+If a download fails or behaves unexpectedly, add `--debug-manifest` to see the raw API responses:
+```bash
+./crunchyroll-downloader --url "..." --etp-rt "$(cat etp_rt.txt)" --debug-manifest
+```
+
+## 7. Available qualities
+
+### Video quality (`-video-quality`)
+
+Set via the `-video-quality` flag as a height string. The code (`mpd.go:42`–`46`) matches the flag against the `Height` field of each representation in the manifest. Common values Crunchyroll serves:
+
+| Flag value | Resolution |
+|---|---|
+| `1080p` | 1920×1080 (default; requires Premium) |
+| `720p` | 1280×720 |
+| `480p` | 854×480 |
+| `360p` | 640×360 |
+
+**Notes:**
+- Not all resolutions are available for every episode — depends on what's in the manifest.
+- If the requested quality isn't found, the code falls back to the first representation and prints a warning (`mpd.go:69`–`71`). The download will still succeed, just at a different quality.
+- Premium (1080p) content requires a Premium account. The `etp_rt` cookie from a free account will fail on premium-only streams.
+
+### Audio quality (`-audio-quality`)
+
+Set via the `-audio-quality` flag. The code (`mpd.go:52`–`63`) matches by bandwidth. Supported values:
+
+| Flag value | Bitrate |
+|---|---|
+| `192k` | ~192 kbps (default) |
+| `128k` | ~128 kbps |
+| `96k` | ~96 kbps |
+
+If the requested quality isn't found, it falls back to the first available audio representation (`mpd.go:69`–`71`).
+
+## 8. Supported languages
+
+The downloader recognizes these locale codes (defined in `utils.go`). Use them with `-audio-lang` and `-subs-lang`:
+
+| Code | Language |
+|---|---|
+| `ja-JP` | 日本語 (Japanese) — default audio |
+| `en-US` | English — default subs |
+| `en-IN` | English (India) |
+| `es-419` | Español (Latin America) |
+| `es-ES` | Español (España) |
+| `pt-BR` | Português (Brasil) |
+| `pt-PT` | Português (Portugal) |
+| `fr-FR` | Français |
+| `de-DE` | Deutsch |
+| `it-IT` | Italiano |
+| `ca-ES` | Català |
+| `ru-RU` | Русский |
+| `ar-SA` | العربية |
+| `hi-IN` | हिंदी |
+| `ta-IN` | தமிழ் |
+| `te-IN` | తెలుగు |
+| `ko-KR` | 한국어 |
+| `zh-CN` | 中文 (普通话) |
+| `zh-HK` | 中文 (粵語) |
+| `zh-TW` | 中文 (國語) |
+| `id-ID` | Bahasa Indonesia |
+| `ms-MY` | Bahasa Melayu |
+| `vi-VN` | Tiếng Việt |
+| `th-TH` | ไทย |
+| `pl-PL` | Polski |
+| `tr-TR` | Türkçe |
+
+**Important:** Not every episode has every language. Available dubs depend on the episode. If a requested audio language is missing, the episode is **skipped** (`download.go:263`). If a requested subtitle language is missing, the episode is **skipped** (`download.go:304`). Use `all` to get only what's actually available.
+
+## 9. Subtitle format (ASS → SRT conversion)
+
+**The downloader fetches subtitles in ASS format** (Advanced SubStation Alpha) — this is hardcoded in the Crunchyroll API (`episode.go:14`–`27`). Subtitles are embedded in the MKV as-is using stream copy (`output.go:48`).
+
+ASS is a rich subtitle format that supports styling, positioning, and effects. Most modern players (VLC, mpv, MPC-HC, Plex, Jellyfin) support ASS natively, so the embedded subs will display correctly.
+
+### Converting to SRT
+
+If you specifically need SRT format (e.g., for a player or tool that doesn't support ASS), convert after download using ffmpeg. SRT is plain text only — styling, positioning, and effects are lost:
+
+```bash
+# Extract and convert the English subtitle track to SRT
+ffmpeg -i "Series Title S01E01 - Episode [1080p].mkv" \
+  -map 0:s:0 -c:s srt \
+  "episode.srt"
+```
+
+If the MKV has multiple subtitle tracks, select by index:
+```bash
+# List all streams to find the right subtitle index
+ffprobe "Series Title S01E01 - Episode [1080p].mkv"
+
+# Extract the 2nd subtitle track (0:s:1)
+ffmpeg -i "input.mkv" -map 0:s:1 -c:s srt "episode_es.srt"
+```
+
+### Batch-convert all subtitles in an MKV to SRT
+
+```bash
+# Get subtitle stream count
+SUB_COUNT=$(ffprobe -v error -select_streams s -show_entries stream=index -of csv=p=0 "input.mkv" | wc -l)
+
+for i in $(seq 0 $((SUB_COUNT - 1))); do
+  ffmpeg -i "input.mkv" -map "0:s:$i" -c:s srt "subtitle_$i.srt"
+done
+```
+
+## 10. Clipping the output
+
+The output MKV is fully decrypted and DRM-free. You can clip it with ffmpeg without any CDM or keys:
+
+```bash
+# Lossless clip (no re-encode) — fast, preserves quality
+ffmpeg -i "input.mkv" \
+  -ss 00:10:00 -to 00:12:30 \
+  -c copy \
+  "clip.mkv"
+
+# Clip with re-encode (use if -c copy produces A/V sync issues at cut points)
+ffmpeg -i "input.mkv" \
+  -ss 00:10:00 -to 00:12:30 \
+  -c:v libx264 -c:a aac \
+  "clip.mp4"
+```
+
+The clips play in any player — no Widevine, no license server, no CDM.
+
+## 11. File layout
+
+```
+crunchyroll-downloader/
+├── main.go              # CLI entry point, flag parsing, URL dispatch
+├── token.go             # Crunchyroll OAuth token exchange (etp_rt → access_token)
+├── http_request.go      # HTTP wrapper with auto token-refresh on 401
+├── episode.go           # Episode metadata + playback API, subtitle URLs
+├── season.go            # Season/series listing API
+├── mpd.go               # DASH manifest parsing, quality selection
+├── download.go          # Segment downloading (parallel), decryption, episode orchestration
+├── drm.go               # Widevine CDM loading, license challenge/response
+├── output.go            # ffmpeg merge → MKV, metadata tagging
+├── utils.go             # Language name/code maps
+├── go.mod / go.sum      # Go dependencies
+├── .gitignore           # Ignores *.wvd, *.mkv, etp_rt.txt, .env
+├── cdm_test.go          # Optional test: verifies .wvd loads correctly
+├── etp_rt.txt           # Your cookie (gitignored — you create this)
+├── *.wvd                # Your CDM (gitignored — you provide this)
+└── crunchyroll-downloader  # Built binary
+```
+
+### Key dependencies
+
+| Package | Purpose |
+|---|---|
+| `github.com/iyear/gowidevine` | Widevine CDM, license challenge, MP4 decryption |
+| `github.com/unki2aut/go-mpd` | DASH manifest (MPD) parsing |
+| `github.com/google/uuid` | Random device ID for auth |
+| `github.com/Eyevink/mp4ff` | MP4 box parsing (indirect, for decryption) |
+
+## 12. Troubleshooting
+
+| Problem | Cause | Fix |
+|---|---|---|
+| `no widevine device provided` | No `.wvd` (or `client_id.bin` + `private_key.pem`) in the working directory | Copy a `.wvd` into the repo folder |
+| `getLicense` error / no keys | CDM is revoked | Swap in a different `.wvd` |
+| `Access token expired` message | Normal — token auto-refreshes | Nothing; it retries automatically |
+| `Audio locale X is not available` | Episode doesn't have that dub | Remove it from `-audio-lang` or use `all` |
+| `Subtitle locale X is not available` | Episode doesn't have that sub | Remove it from `-subs-lang` or use `all` |
+| `failed to get the video base URL` | Wrong `-video-quality` value | Check available qualities; use `1080p`, `720p`, etc. |
+| `failed to get the audio base URL` | Wrong `-audio-quality` value | Use `192k`, `128k`, or `96k` |
+| `ffmpeg failed` | ffmpeg not installed or path issue | `brew install ffmpeg`, verify `which ffmpeg` |
+| Episode skipped silently | Output file already exists | Delete or rename the existing `.mkv` |
+| 401 on premium content | Free account, not Premium | Use a Premium account's `etp_rt` |
+
+## 13. Security notes
+
+- **`etp_rt.txt` is gitignored** — never commit it. The `.gitignore` also blocks `*.wvd`, `*.mkv`, `client_id.bin`, `private_key.pem`, and `.env`.
+- The `etp_rt` cookie grants access to your Crunchyroll account. Treat it like a password.
+- CDMs are leaked device credentials. They are not "yours" — they get revoked and you should not share them publicly.
+- The downloader authenticates as your account. Download only content you have legitimate access to.
+- Decrypted output files are DRM-free. Respect Crunchyroll's terms of service regarding offline copies.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ Usage of ./crunchyroll-downloader:
         Audio language(s), comma-separated for multiple (e.g. "ja-JP,en-US"). First is the default track (default "ja-JP")
   -audio-quality string
         Audio quality (default "192k")
-  -etp-rt string
-        The "etp_rt" cookie value of your account
+  -etp-rt-file string
+        Path to a 0600 regular file containing the "etp_rt" cookie of your account
+        (or set the CRUNCHYROLL_ETP_RT environment variable — the raw value never
+        goes on the command line, where any local process could read it from argv)
   -season int
         Season number. Not used if an episode link is entered
   -subs-lang string
@@ -50,22 +52,22 @@ Usage of ./crunchyroll-downloader:
 
 Ex: to download the first season of *Hell's Paradise*:
 ```shell
-./crunchyroll-downloader --url https://www.crunchyroll.com/series/GJ0H7Q5ZJ/hells-paradise --season 1 --etp-rt replace_this
+./crunchyroll-downloader --url https://www.crunchyroll.com/series/GJ0H7Q5ZJ/hells-paradise --season 1 --etp-rt-file ~/.config/crunchyroll/etp_rt.txt
 ```
 
 To download a specific episode:
 ```shell
-./crunchyroll-downloader --url https://www.crunchyroll.com/watch/GE00198973JAJP/dawn-and-confusion --etp-rt replace_this
+./crunchyroll-downloader --url https://www.crunchyroll.com/watch/GE00198973JAJP/dawn-and-confusion --etp-rt-file ~/.config/crunchyroll/etp_rt.txt
 ```
 
 To batch download from a file (one URL per line):
 ```shell
-./crunchyroll-downloader --urls list.txt --etp-rt replace_this --subs-lang pt-BR
+./crunchyroll-downloader --urls list.txt --etp-rt-file ~/.config/crunchyroll/etp_rt.txt --subs-lang pt-BR
 ```
 
 To download multiple audio tracks and subtitles into a single file (the first of each is set as the default track). If any requested language is missing for an episode, that episode is skipped:
 ```shell
-./crunchyroll-downloader --url https://www.crunchyroll.com/watch/GE00198973JAJP/dawn-and-confusion --etp-rt replace_this --audio-lang ja-JP,en-US --subs-lang en-US,es-419,de-DE
+./crunchyroll-downloader --url https://www.crunchyroll.com/watch/GE00198973JAJP/dawn-and-confusion --etp-rt-file ~/.config/crunchyroll/etp_rt.txt --audio-lang ja-JP,en-US --subs-lang en-US,es-419,de-DE
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -68,6 +68,55 @@ To download multiple audio tracks and subtitles into a single file (the first of
 ./crunchyroll-downloader --url https://www.crunchyroll.com/watch/GE00198973JAJP/dawn-and-confusion --etp-rt-file ~/.config/crunchyroll/etp_rt.txt --audio-lang ja-JP,en-US --subs-lang en-US,es-419,de-DE
 ```
 
+## Resumable subtitle indexing
+
+`--index-subs` opens playback only to collect the exact requested subtitle
+locale. It does not load a Widevine CDM. Authentication remains file-only:
+provide `--etp-rt-file` pointing at a regular mode-`0600` operator-private
+file; do not put a cookie in an environment variable or command-line value.
+
+```shell
+./crunchyroll-downloader \
+  --url https://www.crunchyroll.com/series/GJ0H7Q5ZJ/hells-paradise \
+  --index-subs \
+  --subs-lang en-US \
+  --index-window 25 \
+  --index-terminal-recheck-window 3 \
+  --etp-rt-file ~/.config/crunchyroll/etp_rt.txt
+```
+
+Every attempted provider identity is checkpointed atomically before the next
+one. The default bounded window is 25 identities. Verified raw `.ass` bytes
+are reused by SHA-256 and are never redownloaded merely to regenerate derived
+telemetry. The global playback circuit can pause later attempts with a
+cooldown after consecutive provider code `4294` responses.
+
+Code `4294` by itself is recorded as
+`subtitle_unknown_provider_playback_restriction`; it is not evidence of a
+specific provider cause. `subtitle_provider_rate_limited` is used only when
+the HTTP response or direct rate-limit headers provide supporting evidence.
+The private run summary uses matching outcomes
+`unknown_provider_playback_restriction` and `provider_rate_limited` when the
+circuit is open.
+
+Each checksum-verified subtitle cache records `subtitle_cue_quality` with
+`healthy` or `degraded` outcome, plus counts for malformed, empty, and skipped
+ASS dialogue cues. A cache is marked degraded when it has no usable cues or
+when malformed cues exceed 5%, empty cues exceed 20%, or skipped cues exceed
+5%. Degraded is a quality observation, not a reason to overwrite or
+redownload the original raw ASS bytes.
+
+Rows recorded as `subtitle_missing_locale` or `subtitle_permanent_failed` do
+not receive a full historical playback sweep. A stable per-episode source
+version and catalog snapshot permit only a deterministic, newest-first sparse
+recheck when provider metadata changes, capped by
+`--index-terminal-recheck-window` and never above `--index-window`.
+
+For a multi-URL `--file` index run, provider-call counters are reset for each
+catalog summary. Omit `--index-run-summary` so each catalog uses its own
+default summary path; one explicit summary path is rejected for multiple URLs
+instead of being overwritten.
+
 ## Building
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ Usage of ./crunchyroll-downloader:
         Audio quality (default "192k")
   -etp-rt-file string
         Path to a 0600 regular file containing the "etp_rt" cookie of your account
-        (or set the CRUNCHYROLL_ETP_RT environment variable — the raw value never
-        goes on the command line, where any local process could read it from argv)
   -season int
         Season number. Not used if an episode link is entered
   -subs-lang string

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Downloads anime from Crunchyroll and outputs them in a MKV file.
 
-You won't be banned or anything, I downloaded all Kaguya-Sama seasons to test during 30 mins and everything went fine
+Use the downloader only with an authorized account and content you are entitled to access. Provider restrictions and account enforcement are outside this tool's control.
 
 ## Features
 
@@ -18,7 +18,7 @@ You won't be banned or anything, I downloaded all Kaguya-Sama seasons to test du
 
 - [FFmpeg](https://www.ffmpeg.org/download.html#get-packages)
 - To download Premium-only content, a Crunchyroll Premium account. No, this can't be bypassed and a free trial should be enough
-- Either a `.wvd` file, or a `client_id.bin` and `private_key.pem`
+- For full-media downloads only, an operator-owned and lawfully provisioned `.wvd` file or matching raw device files, stored outside the repository as mode `0600` and selected with `CRUNCHYROLL_WIDEVINE_DEVICE_FILE` (or the paired raw-file environment variables). Subtitle-only indexing does not require a Widevine device.
 
 ## Download
 
@@ -95,9 +95,7 @@ To download multiple audio tracks and subtitles into a single file (the first of
 
 ### What is a `.wvd` file and do I really need one?
 
-Yes, Crunchyroll uses DRM-only content. This file is used to get a Widevine license, which gives the keys to decrypt the media.
-
-If you don't have a rooted Android device or are just lazy, search "ready to use cdms" and you'll find plenty of websites providing those files.
+Full-media downloads require an operator-owned, lawfully provisioned device credential. Subtitle-only indexing does not require one. Keep device credentials outside the repository in private `0600` storage; never use leaked, extracted, shared, or third-party credentials.
 
 ## License
 

--- a/cdm_test.go
+++ b/cdm_test.go
@@ -3,10 +3,46 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/iyear/gowidevine"
 )
+
+func TestOpenPrivateRegularFileRejectsBroadModeAndSymlink(t *testing.T) {
+	dir := t.TempDir()
+	credential := filepath.Join(dir, "device.wvd")
+	if err := os.WriteFile(credential, []byte("fixture-not-a-real-device"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := openPrivateRegularFile(credential)
+	if err != nil {
+		t.Fatalf("mode-0600 regular file rejected: %v", err)
+	}
+	file.Close()
+	if err := os.Chmod(credential, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := openPrivateRegularFile(credential); err == nil {
+		t.Fatal("mode-0644 credential was accepted")
+	}
+	link := filepath.Join(dir, "device-link.wvd")
+	if err := os.Symlink(credential, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := openPrivateRegularFile(link); err == nil {
+		t.Fatal("symlink credential was accepted")
+	}
+}
+
+func TestGetWidevineDeviceRequiresPairedRawPaths(t *testing.T) {
+	t.Setenv("CRUNCHYROLL_WIDEVINE_DEVICE_FILE", "")
+	t.Setenv("CRUNCHYROLL_WIDEVINE_CLIENT_ID_FILE", filepath.Join(t.TempDir(), "client-id"))
+	t.Setenv("CRUNCHYROLL_WIDEVINE_PRIVATE_KEY_FILE", "")
+	if _, err := getWidevineDevice(); err == nil {
+		t.Fatal("unpaired raw credential path was accepted")
+	}
+}
 
 // TestLoadWVD verifies that the .wvd file in the repo folder parses correctly
 // through the gowidevine library — that a CDM can be constructed and that the
@@ -14,10 +50,8 @@ import (
 // any license server; it only validates the file is structurally and
 // cryptographically loadable.
 func TestLoadWVD(t *testing.T) {
-	// getWidevineDevice reads from the current working directory, so make sure
-	// we're running from the repo root where the .wvd lives.
-	if _, err := os.Stat("1668035862.wvd"); err != nil {
-		t.Skipf("no .wvd file in working directory: %v", err)
+	if os.Getenv("CRUNCHYROLL_WIDEVINE_DEVICE_FILE") == "" {
+		t.Skip("CRUNCHYROLL_WIDEVINE_DEVICE_FILE is not configured")
 	}
 
 	device, err := getWidevineDevice()

--- a/cdm_test.go
+++ b/cdm_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/iyear/gowidevine"
+)
+
+// TestLoadWVD verifies that the .wvd file in the repo folder parses correctly
+// through the gowidevine library — that a CDM can be constructed and that the
+// embedded RSA private key and DRM certificate are valid. This does NOT contact
+// any license server; it only validates the file is structurally and
+// cryptographically loadable.
+func TestLoadWVD(t *testing.T) {
+	// getWidevineDevice reads from the current working directory, so make sure
+	// we're running from the repo root where the .wvd lives.
+	if _, err := os.Stat("1668035862.wvd"); err != nil {
+		t.Skipf("no .wvd file in working directory: %v", err)
+	}
+
+	device, err := getWidevineDevice()
+	if err != nil {
+		t.Fatalf("getWidevineDevice returned an error: %v", err)
+	}
+	if device == nil {
+		t.Fatal("getWidevineDevice returned nil — no .wvd or client_id/private_key found")
+	}
+
+	// Construct a CDM from the device. This exercises the key parsing path.
+	cdm := widevine.NewCDM(device)
+	if cdm == nil {
+		t.Fatal("widevine.NewCDM returned nil")
+	}
+
+	// Validate the embedded credentials parsed correctly.
+	clientID := device.ClientID()
+	if clientID == nil {
+		t.Fatal("ClientID() returned nil — client identification blob did not parse")
+	}
+
+	cert := device.DrmCertificate()
+	if cert == nil {
+		t.Fatal("DrmCertificate() returned nil — DRM certificate did not parse")
+	}
+
+	privKey := device.PrivateKey()
+	if privKey == nil {
+		t.Fatal("PrivateKey() returned nil — RSA private key did not parse")
+	}
+
+	// A valid RSA private key must have a non-nil public key and positive N.
+	if privKey.PublicKey.N == nil || privKey.PublicKey.N.Sign() <= 0 {
+		t.Fatal("parsed RSA private key has invalid modulus")
+	}
+
+	fmt.Println("✅ WVD file loaded successfully — CDM constructed.")
+	fmt.Printf("   DRM cert system ID: %d\n", cert.SystemId)
+	fmt.Printf("   RSA key bits:       %d\n", privKey.PublicKey.N.BitLen())
+}

--- a/download.go
+++ b/download.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -18,6 +21,67 @@ import (
 )
 
 const maxWorkers = 10
+
+const maxSubtitleBytes int64 = 16 << 20
+
+const providerHTTPTimeout = 30 * time.Second
+
+// These variables are test-overridable; production provider requests remain
+// bounded even when a provider stalls without returning an HTTP error.
+var subtitleHTTPClient = &http.Client{Timeout: providerHTTPTimeout}
+var segmentHTTPClient = &http.Client{Timeout: providerHTTPTimeout}
+
+// These seams keep the error boundary testable without opening a live playback
+// stream. Production always uses the concrete provider functions.
+var openDownloadPlayback = getEpisode
+var closeDownloadPlayback = deleteStream
+var parseDownloadManifest = parseManifest
+
+// HTTPStatusError reports a response that cannot be used by a caller. Keeping
+// the status on the error lets the index checkpoint distinguish a missing or
+// rejected subtitle from an interrupted local write.
+type HTTPStatusError struct {
+	URL        string
+	StatusCode int
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("unexpected HTTP status %d for %s", e.StatusCode, redactURL(e.URL))
+}
+
+// SubtitleBodyError means a subtitle response was structurally unsafe to
+// cache. The body is deliberately never interpreted or rewritten here: ASS
+// bytes are retained verbatim once validated.
+type SubtitleBodyError struct {
+	URL     string
+	Problem string
+}
+
+func (e *SubtitleBodyError) Error() string {
+	return fmt.Sprintf("invalid subtitle response for %s: %s", redactURL(e.URL), e.Problem)
+}
+
+type SubtitleTransportError struct{ Operation string }
+
+func (e *SubtitleTransportError) Error() string {
+	return "subtitle " + e.Operation + " failed"
+}
+
+var urlInMessageRe = regexp.MustCompile(`https?://[^\s]+`)
+
+// redactURL preserves only scheme and host. Provider URL paths can contain
+// playback/release tokens, so they are never safe to persist or report.
+func redactURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "<redacted-url>"
+	}
+	return parsed.Scheme + "://" + parsed.Host
+}
+
+func redactSensitiveURLs(message string) string {
+	return urlInMessageRe.ReplaceAllStringFunc(message, redactURL)
+}
 
 func buildUrl(base, representationId, file string, partNum *int64) string {
 	if partNum != nil {
@@ -41,7 +105,7 @@ func downloadPart(url string) ([]byte, error) {
 		req.Header.Set("Origin", "https://static.crunchyroll.com")
 		req.Header.Set("Referer", "https://static.crunchyroll.com/")
 		req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0")
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := segmentHTTPClient.Do(req)
 		if err != nil {
 			if attempt < maxRetries-1 {
 				continue
@@ -157,59 +221,155 @@ func downloadParts(baseUrl, representationId *string, set *mpd.AdaptationSet) (s
 	return filename, nil
 }
 
-func downloadSubs(url string) string {
+// fetchSubtitleASS validates and returns the raw ASS response. It intentionally
+// does not parse, normalize, or transcode the response; the index cache is an
+// exact-byte preservation store.
+func fetchSubtitleASS(url string) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		panic(err)
+		return nil, &SubtitleTransportError{Operation: "request construction"}
 	}
 	req.Header.Set("Origin", "https://static.crunchyroll.com")
 	req.Header.Set("Referer", "https://static.crunchyroll.com/")
 	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := subtitleHTTPClient.Do(req)
 	if err != nil {
-		panic(err)
+		return nil, &SubtitleTransportError{Operation: "transport"}
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, &HTTPStatusError{URL: redactURL(url), StatusCode: resp.StatusCode}
+	}
+	if resp.ContentLength == 0 {
+		return nil, &SubtitleBodyError{URL: redactURL(url), Problem: "empty body"}
+	}
+	if resp.ContentLength > maxSubtitleBytes {
+		return nil, &SubtitleBodyError{URL: redactURL(url), Problem: "body exceeds size limit"}
+	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSubtitleBytes+1))
 	if err != nil {
-		panic(err)
+		return nil, &SubtitleBodyError{URL: redactURL(url), Problem: "unable to read body"}
+	}
+	if len(body) == 0 {
+		return nil, &SubtitleBodyError{URL: redactURL(url), Problem: "empty body"}
+	}
+	if int64(len(body)) > maxSubtitleBytes {
+		return nil, &SubtitleBodyError{URL: redactURL(url), Problem: "body exceeds size limit"}
+	}
+	if resp.ContentLength >= 0 && int64(len(body)) != resp.ContentLength {
+		return nil, &SubtitleBodyError{URL: redactURL(url), Problem: "body does not match declared Content-Length"}
+	}
+	if !isASS(body) {
+		return nil, &SubtitleBodyError{URL: redactURL(url), Problem: "body is not an ASS subtitle document"}
+	}
+	return body, nil
+}
+
+// isASS accepts the standard UTF-8 BOM and CRLF line endings, but requires
+// the two structural sections which distinguish an ASS document from a 200
+// HTML/login/error page. It is validation only: the returned cache bytes are
+// never normalized or rewritten.
+func isASS(body []byte) bool {
+	body = bytes.TrimPrefix(body, []byte{0xEF, 0xBB, 0xBF})
+	lines := bytes.Split(body, []byte{'\n'})
+	firstSection := ""
+	seenEvents := false
+	seenFormat := false
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 || line[0] == ';' {
+			continue
+		}
+		if firstSection == "" {
+			firstSection = string(line)
+			if !strings.EqualFold(firstSection, "[Script Info]") {
+				return false
+			}
+			continue
+		}
+		if strings.EqualFold(string(line), "[Events]") {
+			seenEvents = true
+			continue
+		}
+		if seenEvents && strings.HasPrefix(strings.ToLower(string(line)), "format:") {
+			seenFormat = true
+		}
+	}
+	return firstSection != "" && seenEvents && seenFormat
+}
+
+func downloadSubs(url string) (string, error) {
+	body, err := fetchSubtitleASS(url)
+	if err != nil {
+		return "", err
 	}
 
 	filename := getFilename(nil)
 	file, err := os.Create(filename)
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("create subtitle temp file: %w", err)
 	}
-	file.Write(body)
-	file.Close()
+	if _, err := file.Write(body); err != nil {
+		_ = file.Close()
+		_ = os.Remove(filename)
+		return "", fmt.Errorf("write subtitle temp file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(filename)
+		return "", fmt.Errorf("close subtitle temp file: %w", err)
+	}
 
-	return filename
+	return filename, nil
 }
 
-func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLangs []string, videoQuality, audioQuality *string) {
-	sanitize := func(s string) string {
-		if s == "" {
-			return "Unknown"
-		}
-
-		// Characters that are illegal in Windows filenames or break the final path
-		illegal := []string{"\\", "/", ":", "*", "?", "\"", "<", ">", "|", "'", "’", "`", "“", "”"}
-		res := s
-		for _, char := range illegal {
-			res = strings.ReplaceAll(res, char, "_")
-		}
-		for strings.Contains(res, "__") {
-			res = strings.ReplaceAll(res, "__", "_")
-		}
-		return strings.TrimRight(res, " .")
+// sanitize replaces characters that are illegal in filenames or break paths,
+// collapsing repeated underscores and trimming trailing dots/spaces. Shared
+// across the download and index code paths so output paths stay consistent.
+func sanitize(s string) string {
+	if s == "" {
+		return "Unknown"
 	}
 
+	// Characters that are illegal in Windows filenames or break the final path
+	illegal := []string{"\\", "/", ":", "*", "?", "\"", "<", ">", "|", "'", "’", "`", "“", "”"}
+	res := s
+	for _, char := range illegal {
+		res = strings.ReplaceAll(res, char, "_")
+	}
+	for strings.Contains(res, "__") {
+		res = strings.ReplaceAll(res, "__", "_")
+	}
+	return strings.TrimRight(res, " .")
+}
+
+func panicAsError(recovered any) error {
+	switch value := recovered.(type) {
+	case error:
+		return fmt.Errorf("panic recovered: %w", value)
+	default:
+		return fmt.Errorf("panic recovered: %v", value)
+	}
+}
+
+// releaseDownloadPlayback converts a panic in provider cleanup into an error so
+// it cannot hide the original download failure or leave the caller believing a
+// stream was released when it was not.
+func releaseDownloadPlayback(contentID, streamToken string) (released bool, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("release playback stream for %s: %w", contentID, panicAsError(recovered))
+		}
+	}()
+	return closeDownloadPlayback(contentID, streamToken), nil
+}
+
+func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLangs []string, videoQuality, audioQuality *string) (err error) {
 	cleanSeriesTitle := sanitize(info.EpisodeMetadata.SeriesTitle)
 	cleanEpisodeTitle := sanitize(info.Title)
 
-	if _, err := os.Stat(cleanSeriesTitle); err != nil {
-		_ = os.MkdirAll(cleanSeriesTitle, 0777)
+	if err := os.MkdirAll(cleanSeriesTitle, 0777); err != nil {
+		return fmt.Errorf("create output directory %q: %w", cleanSeriesTitle, err)
 	}
 
 	outputFile := filepath.Join(cleanSeriesTitle, fmt.Sprintf("%s S%02dE%02d - %s [%s].mkv",
@@ -222,7 +382,9 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 
 	if _, err := os.Stat(outputFile); err == nil {
 		fmt.Printf("Episode %v is already downloaded, skipping...\n", info.EpisodeMetadata.EpisodeNumber)
-		return
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat output file %q: %w", outputFile, err)
 	}
 
 	// Resolve each requested audio locale to its version GUID. Each dub is a
@@ -260,10 +422,12 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 	for _, locale := range audioLangs {
 		guid, ok := guidByLocale[locale]
 		if !ok {
-			fmt.Printf("! Audio locale %s is not available for episode %v, aborting this episode.\n", locale, info.EpisodeMetadata.EpisodeNumber)
-			return
+			return fmt.Errorf("audio locale %s is not available for episode %v", locale, info.EpisodeMetadata.EpisodeNumber)
 		}
 		versions = append(versions, audioVersion{locale: locale, contentId: guid})
+	}
+	if len(versions) == 0 {
+		return fmt.Errorf("no audio locales were requested for episode %v", info.EpisodeMetadata.EpisodeNumber)
 	}
 
 	fmt.Printf("Downloading: %s (S%02vE%02v) from %s\n", info.Title, info.EpisodeMetadata.SeasonNumber, info.EpisodeMetadata.EpisodeNumber, info.EpisodeMetadata.SeriesTitle)
@@ -272,19 +436,36 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 	// all if anything fails partway through.
 	activeStreams := map[string]string{}
 	defer func() {
-		print("Cleaning up...")
-
+		fmt.Println("Cleaning up...")
+		var cleanupErrs []error
 		for id, sToken := range activeStreams {
-			deleteStream(id, sToken)
+			released, releaseErr := releaseDownloadPlayback(id, sToken)
+			if releaseErr != nil {
+				cleanupErrs = append(cleanupErrs, releaseErr)
+				continue
+			}
+			if !released {
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("release playback stream for %s: provider rejected cleanup", id))
+			}
 		}
-		if r := recover(); r != nil {
-			print("Recovered from error:", r)
+		if recovered := recover(); recovered != nil {
+			err = panicAsError(recovered)
+		}
+		if cleanupErr := errors.Join(cleanupErrs...); cleanupErr != nil {
+			if err == nil {
+				err = cleanupErr
+			} else {
+				err = errors.Join(err, cleanupErr)
+			}
+		}
+		if err != nil {
+			err = fmt.Errorf("download episode %s: %w", baseContentId, err)
 		}
 	}()
 
 	// Fetch the first version's playback first so we can validate subtitle
 	// availability before downloading anything heavy.
-	firstEpisode := getEpisode(versions[0].contentId)
+	firstEpisode := openPlaybackWithRetry(versions[0].contentId, openDownloadPlayback, *playback4294Retries, *playback4294Backoff, sleepPlaybackRetry)
 	activeStreams[versions[0].contentId] = firstEpisode.Token
 
 	if len(subsLangs) == 1 && subsLangs[0] == "all" {
@@ -301,15 +482,18 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 
 	for _, locale := range subsLangs {
 		if firstEpisode.Subtitles[locale] == nil {
-			fmt.Printf("! Subtitle locale %s is not available for episode %v, aborting this episode.\n", locale, info.EpisodeMetadata.EpisodeNumber)
-			return
+			return fmt.Errorf("subtitle locale %s is not available for episode %v", locale, info.EpisodeMetadata.EpisodeNumber)
 		}
 	}
 
 	var subTracks []mediaTrack
 	for _, locale := range subsLangs {
 		fmt.Printf("Downloading subtitles for %s...\n", trackTitle(locale))
-		subTracks = append(subTracks, mediaTrack{file: downloadSubs(firstEpisode.Subtitles[locale].URL), locale: locale})
+		subtitleFile, err := downloadSubs(firstEpisode.Subtitles[locale].URL)
+		if err != nil {
+			return fmt.Errorf("download subtitles for %s: %w", locale, err)
+		}
+		subTracks = append(subTracks, mediaTrack{file: subtitleFile, locale: locale})
 	}
 	if len(subTracks) > 0 {
 		fmt.Println("Downloaded subtitles!")
@@ -321,30 +505,30 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 	for i, version := range versions {
 		episode := firstEpisode
 		if i > 0 {
-			episode = getEpisode(version.contentId)
+			episode = openPlaybackWithRetry(version.contentId, openDownloadPlayback, *playback4294Retries, *playback4294Backoff, sleepPlaybackRetry)
 			activeStreams[version.contentId] = episode.Token
 		}
 
-		manifest := parseManifest(episode.ManifestURL)
+		manifest := parseDownloadManifest(episode.ManifestURL)
 		pssh := getPssh(manifest)
 		if pssh == nil {
-			panic("PSSH not found")
+			return errors.New("PSSH not found")
 		}
 		// getLicense stores the keys in the global "keys" used by downloadParts,
 		// so audio for this version must be downloaded before the next license.
 		if err := getLicense(*pssh, version.contentId, episode.Token); err != nil {
-			panic(fmt.Sprintf("getLicense for %s: %s", version.locale, err))
+			return fmt.Errorf("get license for %s: %w", version.locale, err)
 		}
 
 		audioSet := manifest.Period[0].AdaptationSets[1]
 		fmt.Printf("Downloading %s audio...\n", trackTitle(version.locale))
 		audioBaseUrl, audioRepresentationId := getBaseUrl(audioSet, false, *audioQuality)
 		if audioBaseUrl == nil {
-			panic(fmt.Sprintf("failed to get the audio base URL for %s, maybe the audio quality you entered is wrong?", version.locale))
+			return fmt.Errorf("failed to get the audio base URL for %s; check the requested audio quality", version.locale)
 		}
 		audioFile, err := downloadParts(audioBaseUrl, audioRepresentationId, audioSet)
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("download %s audio: %w", version.locale, err)
 		}
 		audioTracks = append(audioTracks, mediaTrack{file: audioFile, locale: version.locale})
 
@@ -355,24 +539,32 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 			fmt.Println("Downloading video...")
 			baseUrl, representationId := getBaseUrl(videoSet, true, *videoQuality)
 			if baseUrl == nil {
-				panic("failed to get the video base URL, maybe the video quality you entered is wrong?")
+				return errors.New("failed to get the video base URL; check the requested video quality")
 			}
 			videoFile, err = downloadParts(baseUrl, representationId, videoSet)
 			if err != nil {
-				panic(err)
+				return fmt.Errorf("download video: %w", err)
 			}
 		}
 
-		if success := deleteStream(version.contentId, episode.Token); !success {
-			print("Failed to remove the player stream, you will probably have issues downloading other episodes.\n")
+		released, releaseErr := releaseDownloadPlayback(version.contentId, episode.Token)
+		if releaseErr != nil {
+			return releaseErr
+		}
+		if !released {
+			return fmt.Errorf("release playback stream for %s: provider rejected cleanup", version.contentId)
 		}
 		delete(activeStreams, version.contentId)
 	}
 
 	mergeEverything(videoFile, audioTracks, subTracks, outputFile, info)
+	return nil
 }
 
-func downloadSeason(videoQuality, audioQuality *string, audioLangs, subsLangs []string, episodes []SeasonEpisode) {
+func downloadSeason(videoQuality, audioQuality *string, audioLangs, subsLangs []string, episodes []SeasonEpisode) error {
+	if len(episodes) == 0 {
+		return errors.New("season has no episodes")
+	}
 	fmt.Printf("Downloading season %v of %s (%v episodes)\n\n", episodes[0].SeasonNumber, episodes[0].SeriesTitle, len(episodes))
 
 	for _, episode := range episodes {
@@ -382,12 +574,16 @@ func downloadSeason(videoQuality, audioQuality *string, audioLangs, subsLangs []
 				SeasonNumber:       episode.SeasonNumber,
 				EpisodeNumber:      episode.EpisodeNumber,
 				AudioLocale:        episode.AudioLocale,
+				Description:        episode.Description,
 				Versions:           episode.Versions,
 				AvailabilityStarts: episode.AvailabilityStarts,
 			},
 			Title: episode.Title,
 		}
 
-		downloadEpisode(episode.ID, info, audioLangs, subsLangs, videoQuality, audioQuality)
+		if err := downloadEpisode(episode.ID, info, audioLangs, subsLangs, videoQuality, audioQuality); err != nil {
+			return fmt.Errorf("download season %d episode %d: %w", episode.SeasonNumber, episode.EpisodeNumber, err)
+		}
 	}
+	return nil
 }

--- a/download.go
+++ b/download.go
@@ -43,10 +43,20 @@ var parseDownloadManifest = parseManifest
 type HTTPStatusError struct {
 	URL        string
 	StatusCode int
+	RetryAfter string
+	RateLimit  ProviderRateLimitHeaders
 }
 
 func (e *HTTPStatusError) Error() string {
 	return fmt.Sprintf("unexpected HTTP status %d for %s", e.StatusCode, redactURL(e.URL))
+}
+
+func providerRateLimitHeaders(header http.Header) ProviderRateLimitHeaders {
+	return ProviderRateLimitHeaders{
+		Limit:     safeHeaderScalar(header.Get("RateLimit-Limit")),
+		Remaining: safeHeaderScalar(header.Get("RateLimit-Remaining")),
+		Reset:     safeHeaderScalar(header.Get("RateLimit-Reset")),
+	}
 }
 
 // SubtitleBodyError means a subtitle response was structurally unsafe to
@@ -232,13 +242,18 @@ func fetchSubtitleASS(url string) ([]byte, error) {
 	req.Header.Set("Origin", "https://static.crunchyroll.com")
 	req.Header.Set("Referer", "https://static.crunchyroll.com/")
 	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0")
+	recordProviderCall(req)
 	resp, err := subtitleHTTPClient.Do(req)
 	if err != nil {
 		return nil, &SubtitleTransportError{Operation: "transport"}
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, &HTTPStatusError{URL: redactURL(url), StatusCode: resp.StatusCode}
+		return nil, &HTTPStatusError{
+			URL: redactURL(url), StatusCode: resp.StatusCode,
+			RetryAfter: safeHeaderScalar(resp.Header.Get("Retry-After")),
+			RateLimit:  providerRateLimitHeaders(resp.Header),
+		}
 	}
 	if resp.ContentLength == 0 {
 		return nil, &SubtitleBodyError{URL: redactURL(url), Problem: "empty body"}

--- a/download_test.go
+++ b/download_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/unki2aut/go-mpd"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return fn(req) }
+
+func TestFetchSubtitleASSRetainsRawBytesAndRejectsBadStatus(t *testing.T) {
+	raw := []byte("\xEF\xBB\xBF[Script Info]\r\nTitle: raw\r\n[Events]\r\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\r\nDialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,A, B\r\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/raw":
+			_, _ = w.Write(raw)
+		default:
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	}))
+	defer server.Close()
+
+	got, err := fetchSubtitleASS(server.URL + "/raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("raw subtitle bytes changed: got %q want %q", got, raw)
+	}
+	_, err = fetchSubtitleASS(server.URL + "/bad?signature=sentinel-secret")
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected HTTPStatusError, got %v", err)
+	}
+	if strings.Contains(err.Error(), "sentinel-secret") || strings.Contains(statusErr.URL, "sentinel-secret") {
+		t.Fatalf("signed subtitle URL leaked into error: %v", err)
+	}
+}
+
+func TestFetchSubtitleASSTransportAndCheckpointErrorsRedactURLs(t *testing.T) {
+	originalClient := subtitleHTTPClient
+	subtitleHTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("transport failure for https://cdn.example/sub.ass?signature=sentinel-secret")
+	})}
+	defer func() { subtitleHTTPClient = originalClient }()
+	_, err := fetchSubtitleASS("https://cdn.example/sub.ass?signature=sentinel-secret")
+	if !strings.Contains(err.Error(), "subtitle transport failed") || strings.Contains(err.Error(), "sentinel-secret") {
+		t.Fatalf("unsafe transport error: %v", err)
+	}
+	if got := redactSensitiveURLs("cache failed https://cdn.example/sub.ass?signature=sentinel-secret"); strings.Contains(got, "sentinel-secret") {
+		t.Fatalf("unsafe checkpoint error: %q", got)
+	}
+}
+
+func TestProviderErrorRedactionRemovesPlaybackPathTokens(t *testing.T) {
+	err := &HTTPStatusError{URL: "https://api.example/playback/v1/token/episode/path-sentinel?signature=query-sentinel#fragment", StatusCode: http.StatusUnauthorized}
+	message := err.Error()
+	if strings.Contains(message, "path-sentinel") || strings.Contains(message, "query-sentinel") || strings.Contains(message, "fragment") {
+		t.Fatalf("provider path/query token leaked: %q", message)
+	}
+	if !strings.Contains(message, "https://api.example") {
+		t.Fatalf("expected host-only diagnostic, got %q", message)
+	}
+}
+
+func TestFetchSubtitleASSRejectsHTMLAndContentLengthMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("<!doctype html><html><body>sign in</body></html>"))
+	}))
+	defer server.Close()
+	_, err := fetchSubtitleASS(server.URL)
+	var bodyErr *SubtitleBodyError
+	if !errors.As(err, &bodyErr) || bodyErr.Problem != "body is not an ASS subtitle document" {
+		t.Fatalf("expected non-ASS SubtitleBodyError, got %v", err)
+	}
+
+	originalClient := subtitleHTTPClient
+	subtitleHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: 999,
+			Body:          io.NopCloser(bytes.NewReader([]byte("[Script Info]\n[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"))),
+			Header:        make(http.Header),
+			Request:       req,
+		}, nil
+	})}
+	defer func() { subtitleHTTPClient = originalClient }()
+	_, err = fetchSubtitleASS("https://example.invalid/subtitle.ass")
+	if !errors.As(err, &bodyErr) || bodyErr.Problem != "body does not match declared Content-Length" {
+		t.Fatalf("expected content-length SubtitleBodyError, got %v", err)
+	}
+}
+
+func TestDownloadEpisodeReturnsRecoveredPanicAndReleasesActiveStream(t *testing.T) {
+	originalOpen := openDownloadPlayback
+	originalClose := closeDownloadPlayback
+	originalParse := parseDownloadManifest
+	defer func() {
+		openDownloadPlayback = originalOpen
+		closeDownloadPlayback = originalClose
+		parseDownloadManifest = originalParse
+	}()
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(originalWD) }()
+
+	var releasedID, releasedToken string
+	openDownloadPlayback = func(string) Episode {
+		return Episode{ManifestURL: "https://manifest.example/signed", Token: "stream-token"}
+	}
+	parseDownloadManifest = func(string) *mpd.MPD {
+		panic(errors.New("provider E31 playback failure"))
+	}
+	closeDownloadPlayback = func(id, streamToken string) bool {
+		releasedID, releasedToken = id, streamToken
+		return true
+	}
+
+	err = downloadEpisode("GY19Q77GR", EpisodeInfo{
+		EpisodeMetadata: EpisodeMetadata{SeriesTitle: "One Piece", AudioLocale: "ja-JP"},
+		Title:           "Episode 31",
+	}, []string{"ja-JP"}, nil, strPtr("1080p"), strPtr("192k"))
+	if err == nil {
+		t.Fatal("downloadEpisode swallowed the recovered panic")
+	}
+	if got, want := err.Error(), "download episode GY19Q77GR: panic recovered: provider E31 playback failure"; got != want {
+		t.Fatalf("recovered error = %q, want %q", got, want)
+	}
+	if releasedID != "GY19Q77GR" || releasedToken != "stream-token" {
+		t.Fatalf("active playback stream was not released: id=%q token=%q", releasedID, releasedToken)
+	}
+}
+
+func TestProcessURLPropagatesDownloadFailure(t *testing.T) {
+	originalInfo := getProcessEpisodeInfo
+	originalOpen := openDownloadPlayback
+	defer func() {
+		getProcessEpisodeInfo = originalInfo
+		openDownloadPlayback = originalOpen
+	}()
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(originalWD) }()
+
+	getProcessEpisodeInfo = func(string) EpisodeInfo {
+		return EpisodeInfo{
+			EpisodeMetadata: EpisodeMetadata{SeriesTitle: "One Piece", AudioLocale: "ja-JP"},
+			Title:           "Episode 31",
+		}
+	}
+	openDownloadPlayback = func(string) Episode {
+		panic(errors.New("provider E31 playback failure"))
+	}
+
+	err = processUrl("https://www.crunchyroll.com/watch/GY19Q77GR")
+	if err == nil {
+		t.Fatal("processUrl swallowed the episode download failure")
+	}
+	if got, want := err.Error(), "download episode GY19Q77GR: panic recovered: provider E31 playback failure"; got != want {
+		t.Fatalf("processUrl error = %q, want %q", got, want)
+	}
+}
+
+func TestDownloadEpisodeRetries4294ThenUsesSuccessfulPlayback(t *testing.T) {
+	originalOpen := openDownloadPlayback
+	originalClose := closeDownloadPlayback
+	originalParse := parseDownloadManifest
+	originalSleep := sleepPlaybackRetry
+	originalRetries := *playback4294Retries
+	originalBackoff := *playback4294Backoff
+	defer func() {
+		openDownloadPlayback = originalOpen
+		closeDownloadPlayback = originalClose
+		parseDownloadManifest = originalParse
+		sleepPlaybackRetry = originalSleep
+		*playback4294Retries = originalRetries
+		*playback4294Backoff = originalBackoff
+	}()
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(originalWD) }()
+
+	*playback4294Retries = 2
+	*playback4294Backoff = 5 * time.Second
+	var calls int
+	var delays []time.Duration
+	openDownloadPlayback = func(id string) Episode {
+		calls++
+		if calls == 1 {
+			panic(&PlaybackAPIError{EpisodeID: id, Code: playback4294Code})
+		}
+		return Episode{ManifestURL: "https://manifest.example/signed", Token: "stream-token"}
+	}
+	sleepPlaybackRetry = func(delay time.Duration) { delays = append(delays, delay) }
+	parseDownloadManifest = func(string) *mpd.MPD { panic(errors.New("stop after playback")) }
+	closeDownloadPlayback = func(id, streamToken string) bool {
+		return id == "GY19Q77GR" && streamToken == "stream-token"
+	}
+
+	err = downloadEpisode("GY19Q77GR", EpisodeInfo{
+		EpisodeMetadata: EpisodeMetadata{SeriesTitle: "One Piece", AudioLocale: "ja-JP"},
+		Title:           "Episode 31",
+	}, []string{"ja-JP"}, nil, strPtr("1080p"), strPtr("192k"))
+	if err == nil || !strings.Contains(err.Error(), "stop after playback") {
+		t.Fatalf("downloadEpisode() error = %v", err)
+	}
+	if calls != 2 || len(delays) != 1 || delays[0] != 5*time.Second {
+		t.Fatalf("calls=%d delays=%v", calls, delays)
+	}
+}
+
+func TestDownloadEpisodeExhausted4294ReturnsError(t *testing.T) {
+	originalOpen := openDownloadPlayback
+	originalSleep := sleepPlaybackRetry
+	originalRetries := *playback4294Retries
+	originalBackoff := *playback4294Backoff
+	defer func() {
+		openDownloadPlayback = originalOpen
+		sleepPlaybackRetry = originalSleep
+		*playback4294Retries = originalRetries
+		*playback4294Backoff = originalBackoff
+	}()
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(originalWD) }()
+
+	*playback4294Retries = 1
+	*playback4294Backoff = time.Second
+	calls := 0
+	openDownloadPlayback = func(id string) Episode {
+		calls++
+		panic(&PlaybackAPIError{EpisodeID: id, Code: playback4294Code})
+	}
+	sleepPlaybackRetry = func(time.Duration) {}
+
+	err = downloadEpisode("GY19Q77GR", EpisodeInfo{
+		EpisodeMetadata: EpisodeMetadata{SeriesTitle: "One Piece", AudioLocale: "ja-JP"},
+		Title:           "Episode 31",
+	}, []string{"ja-JP"}, nil, strPtr("1080p"), strPtr("192k"))
+	if err == nil || !strings.Contains(err.Error(), "code 4294") || calls != 2 {
+		t.Fatalf("downloadEpisode() error=%v calls=%d", err, calls)
+	}
+}
+
+func strPtr(value string) *string { return &value }

--- a/drm.go
+++ b/drm.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -74,35 +75,41 @@ func sendChallenge(contentId, videoToken string, challenge []byte) ([]byte, erro
 }
 
 func getWidevineDevice() (*widevine.Device, error) {
-	var clientID []byte
-	var privateKey []byte
-	files, _ := os.ReadDir(".")
-	for _, file := range files {
-		if strings.HasSuffix(file.Name(), ".wvd") {
-			wvd, err := os.Open(file.Name())
-			if err != nil {
-				return nil, err
-			}
-
-			return widevine.NewDevice(widevine.FromWVD(io.NopCloser(wvd)))
-		} else if file.Name() == "client_id.bin" {
-			f, err := os.Open("client_id.bin")
-			if err != nil {
-				return nil, err
-			}
-			defer f.Close()
-
-			clientID, err = io.ReadAll(f)
-		} else if file.Name() == "private_key.pem" {
-			f, err := os.Open("private_key.pem")
-			if err != nil {
-				return nil, err
-			}
-			defer f.Close()
-
-			privateKey, err = io.ReadAll(f)
-			break
+	wvdPath := strings.TrimSpace(os.Getenv("CRUNCHYROLL_WIDEVINE_DEVICE_FILE"))
+	if wvdPath != "" {
+		wvd, err := openPrivateRegularFile(wvdPath)
+		if err != nil {
+			return nil, fmt.Errorf("open Widevine device file: %w", err)
 		}
+		defer wvd.Close()
+		return widevine.NewDevice(widevine.FromWVD(io.NopCloser(wvd)))
+	}
+
+	clientIDPath := strings.TrimSpace(os.Getenv("CRUNCHYROLL_WIDEVINE_CLIENT_ID_FILE"))
+	privateKeyPath := strings.TrimSpace(os.Getenv("CRUNCHYROLL_WIDEVINE_PRIVATE_KEY_FILE"))
+	if clientIDPath == "" && privateKeyPath == "" {
+		return nil, nil
+	}
+	if clientIDPath == "" || privateKeyPath == "" {
+		return nil, fmt.Errorf("both CRUNCHYROLL_WIDEVINE_CLIENT_ID_FILE and CRUNCHYROLL_WIDEVINE_PRIVATE_KEY_FILE are required")
+	}
+	clientIDFile, err := openPrivateRegularFile(clientIDPath)
+	if err != nil {
+		return nil, fmt.Errorf("open Widevine client id file: %w", err)
+	}
+	defer clientIDFile.Close()
+	privateKeyFile, err := openPrivateRegularFile(privateKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("open Widevine private key file: %w", err)
+	}
+	defer privateKeyFile.Close()
+	clientID, err := io.ReadAll(clientIDFile)
+	if err != nil {
+		return nil, fmt.Errorf("read Widevine client id file: %w", err)
+	}
+	privateKey, err := io.ReadAll(privateKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("read Widevine private key file: %w", err)
 	}
 
 	if len(clientID) > 0 && len(privateKey) > 0 {
@@ -112,12 +119,40 @@ func getWidevineDevice() (*widevine.Device, error) {
 	return nil, nil
 }
 
+func openPrivateRegularFile(path string) (*os.File, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("credential path must be a regular file")
+	}
+	if info.Mode().Perm() != 0o600 {
+		return nil, fmt.Errorf("credential file mode must be 0600")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	opened, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	if !os.SameFile(info, opened) {
+		file.Close()
+		return nil, fmt.Errorf("credential file changed while opening")
+	}
+	return file, nil
+}
+
 func getLicense(psshData, contentId, videoToken string) error {
 	device, err := getWidevineDevice()
-	if device == nil {
-		return errors.New("no widevine device provided. You either need:\n- a \".wvd\" file,\n- or \"client_id.bin\" and \"private_key.pem\" files.\nI'm not sharing links for obvious reasons, but search \"ready to use cdms\" on Google :)\n")
-	} else if err != nil {
+	if err != nil {
 		return err
+	}
+	if device == nil {
+		return errors.New("no authorized Widevine device configured; set CRUNCHYROLL_WIDEVINE_DEVICE_FILE or both private raw-device file variables for full-media downloads (subtitle indexing requires none)")
 	}
 	cdm := widevine.NewCDM(device)
 	decodedPssh, err := base64.StdEncoding.DecodeString(psshData)

--- a/episode.go
+++ b/episode.go
@@ -177,8 +177,24 @@ func getEpisode(id string) Episode {
 	if err != nil {
 		panic(err)
 	}
-	if err = json.Unmarshal(body, &episode); err != nil {
-		panic(err)
+	decodeErr := json.Unmarshal(body, &episode)
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		if decodeErr == nil && len(episode.Error) > 0 && string(episode.Error) != "null" {
+			providerErr := parsePlaybackAPIError(id, episode.Error)
+			providerErr.HTTPStatus = resp.StatusCode
+			providerErr.RetryAfter = safeHeaderScalar(resp.Header.Get("Retry-After"))
+			providerErr.RateLimit = providerRateLimitHeaders(resp.Header)
+			panic(providerErr)
+		}
+		panic(&HTTPStatusError{
+			URL:        redactURL(req.URL.String()),
+			StatusCode: resp.StatusCode,
+			RetryAfter: safeHeaderScalar(resp.Header.Get("Retry-After")),
+			RateLimit:  providerRateLimitHeaders(resp.Header),
+		})
+	}
+	if decodeErr != nil {
+		panic(decodeErr)
 	}
 	if len(episode.Error) > 0 && string(episode.Error) != "null" {
 		// Panic rather than os.Exit so callers (download loop, index loop) can

--- a/episode.go
+++ b/episode.go
@@ -2,11 +2,126 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
+	"strconv"
+	"strings"
+	"time"
 )
+
+const playback4294Code = "4294"
+
+// PlaybackAPIError is the safe, typed provider boundary for playback-open
+// failures. It deliberately retains only the episode ID and parsed scalar
+// code/message; the raw provider body is never stored or formatted.
+type PlaybackAPIError struct {
+	EpisodeID string
+	Code      string
+	Message   string
+}
+
+func (e *PlaybackAPIError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("playback API error for %s: code %s: %s", e.EpisodeID, e.Code, e.Message)
+	}
+	return fmt.Sprintf("playback API error for %s: code %s", e.EpisodeID, e.Code)
+}
+
+func safeProviderMessage(message string) string {
+	message = strings.Join(strings.Fields(message), " ")
+	message = redactSensitiveURLs(message)
+	const maxProviderMessageBytes = 160
+	if len(message) > maxProviderMessageBytes {
+		message = message[:maxProviderMessageBytes] + "..."
+	}
+	return message
+}
+
+func providerCode(value any) string {
+	switch value := value.(type) {
+	case json.Number:
+		return value.String()
+	case string:
+		if _, err := strconv.ParseInt(value, 10, 64); err == nil {
+			return value
+		}
+	case float64:
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	}
+	return "unknown"
+}
+
+func parsePlaybackAPIError(episodeID string, raw json.RawMessage) *PlaybackAPIError {
+	parsed := &PlaybackAPIError{EpisodeID: episodeID, Code: "unknown"}
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		parsed.Message = "provider returned an unreadable error"
+		return parsed
+	}
+	switch value := value.(type) {
+	case json.Number:
+		parsed.Code = providerCode(value)
+	case string:
+		if code := providerCode(value); code != "unknown" {
+			parsed.Code = code
+		} else {
+			parsed.Message = safeProviderMessage(value)
+		}
+	case map[string]any:
+		parsed.Code = providerCode(value["code"])
+		if message, ok := value["message"].(string); ok {
+			parsed.Message = safeProviderMessage(message)
+		}
+	default:
+		parsed.Message = "provider returned an unrecognized error"
+	}
+	return parsed
+}
+
+type playbackOpener func(string) Episode
+type playbackSleeper func(time.Duration)
+
+var sleepPlaybackRetry playbackSleeper = time.Sleep
+
+func playbackRetryDelay(base time.Duration, retry int) time.Duration {
+	delay := base
+	for i := 0; i < retry && delay < maxPlayback4294Backoff; i++ {
+		delay *= 2
+		if delay > maxPlayback4294Backoff {
+			delay = maxPlayback4294Backoff
+		}
+	}
+	return delay
+}
+
+// openPlaybackWithRetry retries only the provider's typed 4294 response.
+// Other panics retain their original value and propagate immediately.
+func openPlaybackWithRetry(id string, open playbackOpener, retries int, backoff time.Duration, sleep playbackSleeper) Episode {
+	for attempt := 0; ; attempt++ {
+		var episode Episode
+		var recovered any
+		func() {
+			defer func() { recovered = recover() }()
+			episode = open(id)
+		}()
+		if recovered == nil {
+			return episode
+		}
+		err, ok := recovered.(error)
+		if !ok {
+			panic(recovered)
+		}
+		var playbackErr *PlaybackAPIError
+		if !errors.As(err, &playbackErr) || playbackErr.Code != playback4294Code || attempt >= retries {
+			panic(recovered)
+		}
+		sleep(playbackRetryDelay(backoff, attempt))
+	}
+}
 
 type Episode struct {
 	// Dash manifest file URL
@@ -15,8 +130,9 @@ type Episode struct {
 	Subtitles map[string]*Subtitle `json:"subtitles"`
 	// Token to give to the Widevine CDM challenge
 	Token string `json:"token"`
-	// Error, `nil` if there's no error
-	Error *string `json:"error"`
+	// Error, `nil` if there's no error. Crunchyroll returns this as a string
+	// or sometimes a number, so use json.RawMessage to tolerate either.
+	Error json.RawMessage `json:"error"`
 }
 
 type Subtitle struct {
@@ -47,9 +163,10 @@ func getEpisode(id string) Episode {
 	if err = json.Unmarshal(body, &episode); err != nil {
 		panic(err)
 	}
-	if episode.Error != nil {
-		print("Error:", *episode.Error)
-		os.Exit(1)
+	if len(episode.Error) > 0 && string(episode.Error) != "null" {
+		// Panic rather than os.Exit so callers (download loop, index loop) can
+		// recover and continue past a single bad episode instead of dying.
+		panic(parsePlaybackAPIError(id, episode.Error))
 	}
 
 	if *debug {
@@ -74,6 +191,7 @@ type EpisodeMetadata struct {
 	EpisodeNumber int    `json:"episode_number"`
 	SeasonNumber  int    `json:"season_number"`
 	SeriesTitle   string `json:"series_title"`
+	Description   string `json:"description"`
 	// AvailabilityStarts represents the date when the episode was released on Crunchyroll
 	AvailabilityStarts string        `json:"availability_starts"`
 	Versions           []*DubVersion `json:"versions"`
@@ -121,6 +239,7 @@ func deleteStream(contentId, sToken string) bool {
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 
 	return resp.StatusCode == http.StatusNoContent
 }

--- a/episode.go
+++ b/episode.go
@@ -17,9 +17,12 @@ const playback4294Code = "4294"
 // failures. It deliberately retains only the episode ID and parsed scalar
 // code/message; the raw provider body is never stored or formatted.
 type PlaybackAPIError struct {
-	EpisodeID string
-	Code      string
-	Message   string
+	EpisodeID  string
+	Code       string
+	Message    string
+	HTTPStatus int
+	RetryAfter string
+	RateLimit  ProviderRateLimitHeaders
 }
 
 func (e *PlaybackAPIError) Error() string {
@@ -37,6 +40,20 @@ func safeProviderMessage(message string) string {
 		message = message[:maxProviderMessageBytes] + "..."
 	}
 	return message
+}
+
+func safeHeaderScalar(value string) string {
+	value = strings.Join(strings.Fields(value), " ")
+	if len(value) > 80 {
+		return value[:80]
+	}
+	return value
+}
+
+type ProviderRateLimitHeaders struct {
+	Limit     string `json:"limit,omitempty"`
+	Remaining string `json:"remaining,omitempty"`
+	Reset     string `json:"reset,omitempty"`
 }
 
 func providerCode(value any) string {
@@ -166,7 +183,11 @@ func getEpisode(id string) Episode {
 	if len(episode.Error) > 0 && string(episode.Error) != "null" {
 		// Panic rather than os.Exit so callers (download loop, index loop) can
 		// recover and continue past a single bad episode instead of dying.
-		panic(parsePlaybackAPIError(id, episode.Error))
+		providerErr := parsePlaybackAPIError(id, episode.Error)
+		providerErr.HTTPStatus = resp.StatusCode
+		providerErr.RetryAfter = safeHeaderScalar(resp.Header.Get("Retry-After"))
+		providerErr.RateLimit = providerRateLimitHeaders(resp.Header)
+		panic(providerErr)
 	}
 
 	if *debug {

--- a/episode_test.go
+++ b/episode_test.go
@@ -2,11 +2,55 @@ package main
 
 import (
 	"errors"
+	"io"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestGetEpisodeRejectsJSONAndNonJSON429AtHTTPBoundary(t *testing.T) {
+	originalClient := authenticatedHTTPClient
+	t.Cleanup(func() { authenticatedHTTPClient = originalClient })
+
+	for _, test := range []struct {
+		name string
+		body string
+	}{
+		{name: "json", body: `{}`},
+		{name: "non-json", body: `rate limited`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			authenticatedHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				header := make(http.Header)
+				header.Set("Retry-After", "17")
+				header.Set("RateLimit-Limit", "20")
+				header.Set("RateLimit-Remaining", "0")
+				header.Set("RateLimit-Reset", "123")
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader(test.body)),
+					Request:    req,
+				}, nil
+			})}
+
+			var recovered any
+			func() {
+				defer func() { recovered = recover() }()
+				_ = getEpisode("episode")
+			}()
+			var statusErr *HTTPStatusError
+			if !errors.As(asError(recovered), &statusErr) {
+				t.Fatalf("recovered=%#v, want HTTPStatusError", recovered)
+			}
+			if statusErr.StatusCode != http.StatusTooManyRequests || statusErr.RetryAfter != "17" || statusErr.RateLimit.Limit != "20" || statusErr.RateLimit.Remaining != "0" || statusErr.RateLimit.Reset != "123" {
+				t.Fatalf("typed playback HTTP error lost evidence: %#v", statusErr)
+			}
+		})
+	}
+}
 
 func TestParsePlaybackAPIErrorAcceptsNumericAndString4294(t *testing.T) {
 	for _, raw := range []string{"4294", `"4294"`} {

--- a/episode_test.go
+++ b/episode_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParsePlaybackAPIErrorAcceptsNumericAndString4294(t *testing.T) {
+	for _, raw := range []string{"4294", `"4294"`} {
+		err := parsePlaybackAPIError("GY19Q77GR", []byte(raw))
+		if err.EpisodeID != "GY19Q77GR" || err.Code != playback4294Code {
+			t.Fatalf("parsePlaybackAPIError(%s) = %#v", raw, err)
+		}
+		if strings.Contains(err.Error(), raw) && strings.Contains(raw, `"`) {
+			t.Fatalf("typed error exposed raw JSON syntax: %q", err.Error())
+		}
+	}
+}
+
+func TestParsePlaybackAPIErrorNeverFormatsRawObject(t *testing.T) {
+	raw := []byte(`{"code":5001,"message":"denied https://api.example/token/sentinel?secret=value","token":"body-secret"}`)
+	err := parsePlaybackAPIError("episode", raw)
+	if err.Code != "5001" || strings.Contains(err.Error(), "sentinel") || strings.Contains(err.Error(), "value") || strings.Contains(err.Error(), "body-secret") {
+		t.Fatalf("unsafe typed playback error: %q", err.Error())
+	}
+}
+
+func TestOpenPlaybackWithRetryNon4294DoesNotRetry(t *testing.T) {
+	calls := 0
+	defer func() {
+		recovered := recover()
+		var playbackErr *PlaybackAPIError
+		if !errors.As(asError(recovered), &playbackErr) || playbackErr.Code != "5001" {
+			t.Fatalf("recovered = %#v", recovered)
+		}
+		if calls != 1 {
+			t.Fatalf("calls = %d, want 1", calls)
+		}
+	}()
+	openPlaybackWithRetry("episode", func(string) Episode {
+		calls++
+		panic(&PlaybackAPIError{EpisodeID: "episode", Code: "5001"})
+	}, 3, time.Second, func(time.Duration) { t.Fatal("unexpected sleep") })
+}
+
+func TestOpenPlaybackWithRetryThenSucceeds(t *testing.T) {
+	calls := 0
+	var delays []time.Duration
+	episode := openPlaybackWithRetry("episode", func(string) Episode {
+		calls++
+		if calls == 1 {
+			panic(&PlaybackAPIError{EpisodeID: "episode", Code: playback4294Code})
+		}
+		return Episode{Token: "stream"}
+	}, 2, 3*time.Second, func(delay time.Duration) { delays = append(delays, delay) })
+	if calls != 2 || episode.Token != "stream" || !reflect.DeepEqual(delays, []time.Duration{3 * time.Second}) {
+		t.Fatalf("calls=%d episode=%#v delays=%v", calls, episode, delays)
+	}
+}
+
+func TestOpenPlaybackWithRetryExhaustsBoundedAttemptsAndBackoff(t *testing.T) {
+	calls := 0
+	var delays []time.Duration
+	defer func() {
+		recovered := recover()
+		var playbackErr *PlaybackAPIError
+		if !errors.As(asError(recovered), &playbackErr) || playbackErr.Code != playback4294Code {
+			t.Fatalf("recovered = %#v", recovered)
+		}
+		if calls != 4 {
+			t.Fatalf("calls = %d, want 4", calls)
+		}
+		want := []time.Duration{20 * time.Second, 40 * time.Second, time.Minute}
+		if !reflect.DeepEqual(delays, want) {
+			t.Fatalf("delays = %v, want %v", delays, want)
+		}
+	}()
+	openPlaybackWithRetry("episode", func(string) Episode {
+		calls++
+		panic(&PlaybackAPIError{EpisodeID: "episode", Code: playback4294Code})
+	}, 3, 20*time.Second, func(delay time.Duration) { delays = append(delays, delay) })
+}
+
+func asError(value any) error {
+	err, _ := value.(error)
+	return err
+}

--- a/http_request.go
+++ b/http_request.go
@@ -48,6 +48,7 @@ func DoRequest(req *http.Request) (*http.Response, error) {
 	if err := ensureReplayableBody(req); err != nil {
 		return nil, err
 	}
+	recordProviderCall(req)
 	resp, err := authenticatedHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -70,6 +71,7 @@ func DoRequest(req *http.Request) (*http.Response, error) {
 		retry.Body = body
 	}
 	retry.Header.Set("Authorization", "Bearer "+token)
+	recordProviderCall(retry)
 	resp, err = authenticatedHTTPClient.Do(retry)
 	if err != nil {
 		return nil, err

--- a/http_request.go
+++ b/http_request.go
@@ -1,23 +1,82 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"net/http"
 )
 
+var authenticatedHTTPClient = &http.Client{Timeout: providerHTTPTimeout}
+
+const maxRetryRequestBodyBytes int64 = 8 << 20
+
+type RequestRetryBodyError struct{ Problem string }
+
+func (e *RequestRetryBodyError) Error() string {
+	return "cannot safely replay authenticated request body: " + e.Problem
+}
+
+// ensureReplayableBody captures only requests whose constructors did not set
+// GetBody (for example io.NopCloser(bytes.NewReader(...))). The buffered bytes
+// stay in memory, are size-bounded, and are never logged.
+func ensureReplayableBody(req *http.Request) error {
+	if req.Body == nil || req.GetBody != nil {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(req.Body, maxRetryRequestBodyBytes+1))
+	if closeErr := req.Body.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return &RequestRetryBodyError{Problem: "read body"}
+	}
+	if int64(len(body)) > maxRetryRequestBodyBytes {
+		return &RequestRetryBodyError{Problem: "body exceeds replay limit"}
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	return nil
+}
+
+// DoRequest makes one request and permits at most one credential refresh. The
+// initial 401 body is closed before retrying, avoiding leaked connections and
+// unbounded recursive retries when credentials are no longer accepted.
 func DoRequest(req *http.Request) (*http.Response, error) {
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	if err := ensureReplayableBody(req); err != nil {
+		return nil, err
+	}
+	resp, err := authenticatedHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+	_ = resp.Body.Close()
+
+	if err := refreshAccessToken(); err != nil {
+		return nil, fmt.Errorf("refresh access token after 401: %w", err)
+	}
+	retry := req.Clone(req.Context())
+	retry.Header = req.Header.Clone()
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, &RequestRetryBodyError{Problem: "reconstruct body"}
+		}
+		retry.Body = body
+	}
+	retry.Header.Set("Authorization", "Bearer "+token)
+	resp, err = authenticatedHTTPClient.Do(retry)
 	if err != nil {
 		return nil, err
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		print("Access token expired. Refetching one...\n")
-		// Refetch an access token
-		token = GetAccessToken(*etpRt)
-		req.Header.Set("Authorization", "Bearer "+token)
-		// and retry the request
-		return DoRequest(req)
+		_ = resp.Body.Close()
+		return nil, &HTTPStatusError{URL: redactURL(retry.URL.String()), StatusCode: http.StatusUnauthorized}
 	}
-
-	return resp, err
+	return resp, nil
 }

--- a/http_request_test.go
+++ b/http_request_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDoRequestRetries401OnlyOnce(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"fresh","account_id":"same"}`))
+		default:
+			requests++
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer server.Close()
+
+	oldEndpoint, oldToken := tokenEndpoint, token
+	tokenEndpoint = server.URL + "/token"
+	token = "expired"
+	authState.Lock()
+	oldSecret, oldAccountID := authState.etpRT, authState.accountID
+	authState.etpRT, authState.accountID = "cookie", "same"
+	authState.Unlock()
+	defer func() {
+		tokenEndpoint, token = oldEndpoint, oldToken
+		authState.Lock()
+		authState.etpRT, authState.accountID = oldSecret, oldAccountID
+		authState.Unlock()
+	}()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/resource", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := DoRequest(req)
+	if resp != nil {
+		t.Fatal("terminal 401 response must be closed and discarded")
+	}
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected terminal HTTPStatusError, got %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want exactly 2", requests)
+	}
+}
+
+func TestProviderHTTPClientsHaveBoundedTimeouts(t *testing.T) {
+	for name, client := range map[string]*http.Client{
+		"subtitle":      subtitleHTTPClient,
+		"segment":       segmentHTTPClient,
+		"manifest":      manifestHTTPClient,
+		"token":         tokenHTTPClient,
+		"authenticated": authenticatedHTTPClient,
+	} {
+		if client == nil || client.Timeout <= 0 {
+			t.Fatalf("%s client does not have a bounded timeout", name)
+		}
+	}
+}
+
+func TestDoRequestReplaysPOSTBodyAfter401(t *testing.T) {
+	want := []byte("widevine-challenge-bytes")
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			_, _ = w.Write([]byte(`{"access_token":"fresh","account_id":"same"}`))
+		case "/license":
+			requests++
+			got, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read request body: %v", err)
+				return
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("request %d body = %q, want %q", requests, got, want)
+			}
+			if requests == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	oldEndpoint, oldToken := tokenEndpoint, token
+	tokenEndpoint, token = server.URL+"/token", "expired"
+	authState.Lock()
+	oldSecret, oldAccountID := authState.etpRT, authState.accountID
+	authState.etpRT, authState.accountID = "cookie", "same"
+	authState.Unlock()
+	defer func() {
+		tokenEndpoint, token = oldEndpoint, oldToken
+		authState.Lock()
+		authState.etpRT, authState.accountID = oldSecret, oldAccountID
+		authState.Unlock()
+	}()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/license", io.NopCloser(bytes.NewReader(want)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.GetBody != nil {
+		t.Fatal("test requires a request constructor without GetBody")
+	}
+	resp, err := DoRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent || requests != 2 {
+		t.Fatalf("status=%d requests=%d, want 204 and 2", resp.StatusCode, requests)
+	}
+}

--- a/index.go
+++ b/index.go
@@ -15,8 +15,19 @@ import (
 	"time"
 )
 
-const rawASSParserVersion = "raw-ass/v1"
-const minimumIndexDelaySeconds = 2
+const (
+	rawASSParserVersion         = "raw-ass/v1"
+	assCueQualityVersion        = "ass-cue-quality/v1"
+	indexCatalogSnapshotVersion = "catalog-snapshot/v1"
+	minimumIndexDelaySeconds    = 2
+
+	// These limits are deliberately persisted with each cue-quality record so
+	// an operator can tell which policy produced a degraded result. A raw ASS
+	// cache remains canonical and is never rewritten to satisfy this policy.
+	maxMalformedASSCueRatio = 0.05
+	maxEmptyASSCueRatio     = 0.20
+	maxSkippedASSCueRatio   = 0.05
+)
 
 var openIndexPlayback playbackOpener = getEpisode
 
@@ -27,21 +38,33 @@ const (
 	indexStatusSubtitleMissing = "subtitle_missing_locale"
 	indexStatusRetryableFailed = "subtitle_retryable_failed"
 	indexStatusPermanentFailed = "subtitle_permanent_failed"
-	indexStatusThrottled       = "subtitle_throttled"
+	// A provider application code alone does not establish why playback was
+	// restricted. Keep the causal claim neutral unless the HTTP response or
+	// rate-limit headers independently establish it.
+	indexStatusUnknownProviderPlaybackRestriction = "subtitle_unknown_provider_playback_restriction"
+	indexStatusProviderRateLimited                = "subtitle_provider_rate_limited"
 	// Deprecated source alias retained for older focused tests and callers;
 	// serialized checkpoints use the typed retryable value above.
 	indexStatusSubtitleFailed = indexStatusRetryableFailed
 )
 
+const legacyIndexStatusThrottled = "subtitle_throttled"
+
+const (
+	providerRestrictionUnknown     = "unknown_provider_playback_restriction"
+	providerRestrictionRateLimited = "direct_rate_limit_evidence"
+)
+
 // indexFile is a durable, self-contained checkpoint. Every terminal episode
 // state is followed by an atomic rewrite of this full snapshot.
 type indexFile struct {
-	Series     string          `json:"series"`
-	SeriesURL  string          `json:"series_url"`
-	IndexedAt  string          `json:"indexed_at"`
-	SubsLang   string          `json:"subs_lang,omitempty"`
-	Seasons    []indexSeason   `json:"seasons"`
-	Checkpoint indexCheckpoint `json:"checkpoint,omitempty"`
+	Series          string          `json:"series"`
+	SeriesURL       string          `json:"series_url"`
+	IndexedAt       string          `json:"indexed_at"`
+	SubsLang        string          `json:"subs_lang,omitempty"`
+	CatalogSnapshot string          `json:"catalog_snapshot,omitempty"`
+	Seasons         []indexSeason   `json:"seasons"`
+	Checkpoint      indexCheckpoint `json:"checkpoint,omitempty"`
 }
 
 type indexCheckpoint struct {
@@ -55,6 +78,23 @@ type indexCircuitState struct {
 	Consecutive4294       int    `json:"consecutive_4294"`
 	OpenedAt              string `json:"opened_at,omitempty"`
 	NextEligibleAttemptAt string `json:"next_eligible_attempt_at,omitempty"`
+	RestrictionEvidence   string `json:"restriction_evidence,omitempty"`
+}
+
+// subtitleCueQuality records a local, derived assessment of the preserved raw
+// ASS bytes. It is telemetry only: the raw file and checksum remain the cache
+// contract even when this outcome is degraded.
+type subtitleCueQuality struct {
+	Version              string  `json:"version"`
+	TotalCues            int     `json:"total_cues"`
+	UsableCues           int     `json:"usable_cues"`
+	MalformedCues        int     `json:"malformed_cues"`
+	EmptyCues            int     `json:"empty_cues"`
+	SkippedCues          int     `json:"skipped_cues"`
+	MaxMalformedCueRatio float64 `json:"max_malformed_cue_ratio"`
+	MaxEmptyCueRatio     float64 `json:"max_empty_cue_ratio"`
+	MaxSkippedCueRatio   float64 `json:"max_skipped_cue_ratio"`
+	Outcome              string  `json:"outcome"`
 }
 
 type indexSeason struct {
@@ -63,30 +103,36 @@ type indexSeason struct {
 }
 
 type indexEpisode struct {
-	Episode                   int                      `json:"episode"`
-	Title                     string                   `json:"title"`
-	Description               string                   `json:"description,omitempty"`
-	ID                        string                   `json:"id"`
-	URL                       string                   `json:"url"`
-	AirDate                   string                   `json:"air_date,omitempty"`
-	AudioLangs                []string                 `json:"audio_langs,omitempty"`
-	SubtitleLangs             []string                 `json:"subtitle_langs,omitempty"`
-	Status                    string                   `json:"status"`
-	SubtitleFile              string                   `json:"subtitle_file,omitempty"`
-	SubtitleLocale            string                   `json:"subtitle_locale,omitempty"`
-	SubtitleSHA256            string                   `json:"subtitle_sha256,omitempty"`
-	SubtitleParserVersion     string                   `json:"subtitle_parser_version,omitempty"`
-	SubtitleAttemptCount      int                      `json:"subtitle_attempt_count,omitempty"`
-	SubtitleFetchAttemptCount int                      `json:"subtitle_fetch_attempt_count,omitempty"`
-	StreamReleaseAttemptCount int                      `json:"stream_release_attempt_count,omitempty"`
-	SubtitleLastAttemptAt     string                   `json:"subtitle_last_attempt_at,omitempty"`
-	SubtitleNextEligibleAt    string                   `json:"subtitle_next_eligible_at,omitempty"`
-	HTTPStatus                int                      `json:"http_status,omitempty"`
-	ProviderApplicationCode   string                   `json:"provider_application_code,omitempty"`
-	RetryAfter                string                   `json:"retry_after,omitempty"`
-	RateLimit                 ProviderRateLimitHeaders `json:"rate_limit,omitempty"`
-	StreamReleaseOutcome      string                   `json:"stream_release_outcome,omitempty"`
-	Error                     string                   `json:"error,omitempty"`
+	Episode                      int                      `json:"episode"`
+	Title                        string                   `json:"title"`
+	Description                  string                   `json:"description,omitempty"`
+	ID                           string                   `json:"id"`
+	URL                          string                   `json:"url"`
+	AirDate                      string                   `json:"air_date,omitempty"`
+	AudioLangs                   []string                 `json:"audio_langs,omitempty"`
+	SubtitleLangs                []string                 `json:"subtitle_langs,omitempty"`
+	Status                       string                   `json:"status"`
+	SubtitleFile                 string                   `json:"subtitle_file,omitempty"`
+	SubtitleLocale               string                   `json:"subtitle_locale,omitempty"`
+	SubtitleSHA256               string                   `json:"subtitle_sha256,omitempty"`
+	SubtitleParserVersion        string                   `json:"subtitle_parser_version,omitempty"`
+	SubtitleCueQuality           *subtitleCueQuality      `json:"subtitle_cue_quality,omitempty"`
+	SubtitleAttemptCount         int                      `json:"subtitle_attempt_count,omitempty"`
+	SubtitleFetchAttemptCount    int                      `json:"subtitle_fetch_attempt_count,omitempty"`
+	StreamReleaseAttemptCount    int                      `json:"stream_release_attempt_count,omitempty"`
+	SubtitleLastAttemptAt        string                   `json:"subtitle_last_attempt_at,omitempty"`
+	SubtitleNextEligibleAt       string                   `json:"subtitle_next_eligible_at,omitempty"`
+	HTTPStatus                   int                      `json:"http_status,omitempty"`
+	ProviderApplicationCode      string                   `json:"provider_application_code,omitempty"`
+	RetryAfter                   string                   `json:"retry_after,omitempty"`
+	RateLimit                    ProviderRateLimitHeaders `json:"rate_limit,omitempty"`
+	StreamReleaseOutcome         string                   `json:"stream_release_outcome,omitempty"`
+	ProviderRestriction          string                   `json:"provider_restriction,omitempty"`
+	SourceVersion                string                   `json:"source_version,omitempty"`
+	SubtitleCheckedSourceVersion string                   `json:"subtitle_checked_source_version,omitempty"`
+	SubtitleRecheckSnapshot      string                   `json:"subtitle_recheck_snapshot,omitempty"`
+	SubtitleRecheckReason        string                   `json:"subtitle_recheck_reason,omitempty"`
+	Error                        string                   `json:"error,omitempty"`
 }
 
 func (episode indexEpisode) isVerifiedRawASS() bool {
@@ -95,6 +141,109 @@ func (episode indexEpisode) isVerifiedRawASS() bool {
 		episode.SubtitleLocale != "" &&
 		episode.SubtitleSHA256 != "" &&
 		episode.SubtitleParserVersion == rawASSParserVersion
+}
+
+func normalizeIndexStatus(status string) string {
+	switch status {
+	case legacyIndexStatusThrottled:
+		// Older checkpoints inferred a rate cause from application code 4294.
+		// Keep their durable attempts and files, but carry the neutral meaning
+		// forward instead of preserving that unsupported inference.
+		return indexStatusUnknownProviderPlaybackRestriction
+	case "subtitle_failed":
+		return indexStatusRetryableFailed
+	default:
+		return status
+	}
+}
+
+func stableSnapshotHash(parts []string) string {
+	hash := sha256.New()
+	for _, part := range parts {
+		_, _ = fmt.Fprintf(hash, "%d:", len(part))
+		_, _ = hash.Write([]byte(part))
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+// episodeSourceVersion fingerprints only provider catalog fields that can
+// change an episode's playable identity or subtitle availability context. It
+// never uses wall-clock time, so an unchanged provider snapshot cannot cause a
+// terminal row to be rechecked merely because another run occurred.
+func episodeSourceVersion(ep SeasonEpisode) string {
+	versions := make([]string, 0, len(ep.Versions))
+	for _, version := range ep.Versions {
+		if version == nil {
+			continue
+		}
+		versions = append(versions, version.AudioLocale+"\x00"+version.GUID)
+	}
+	sort.Strings(versions)
+	parts := []string{
+		"episode-source/v1", ep.ID, strconv.Itoa(ep.SeasonNumber), strconv.Itoa(ep.EpisodeNumber),
+		ep.AvailabilityStarts, ep.AudioLocale, ep.Title, ep.Description,
+	}
+	parts = append(parts, versions...)
+	return "episode-source/v1:" + stableSnapshotHash(parts)
+}
+
+// catalogSnapshot is a stable identity for the discovered provider catalog.
+// It lets terminal rows be revisited only when the source snapshot changes;
+// selection itself remains explicitly capped elsewhere.
+func catalogSnapshot(catalog indexFile) string {
+	entries := make([]string, 0)
+	for _, season := range catalog.Seasons {
+		for _, episode := range season.Episodes {
+			entries = append(entries, episode.ID+"\x00"+episode.SourceVersion)
+		}
+	}
+	sort.Strings(entries)
+	parts := []string{indexCatalogSnapshotVersion, catalog.SeriesURL, catalog.SubsLang}
+	parts = append(parts, entries...)
+	return indexCatalogSnapshotVersion + ":" + stableSnapshotHash(parts)
+}
+
+func copyCueQuality(quality *subtitleCueQuality) *subtitleCueQuality {
+	if quality == nil {
+		return nil
+	}
+	copied := *quality
+	return &copied
+}
+
+func cueQualityForVerifiedRawASS(prior indexEpisode) *subtitleCueQuality {
+	if prior.SubtitleCueQuality != nil && prior.SubtitleCueQuality.Version == assCueQualityVersion {
+		return copyCueQuality(prior.SubtitleCueQuality)
+	}
+	raw, err := os.ReadFile(prior.SubtitleFile)
+	if err != nil {
+		// The checksum verification immediately before this local read is the
+		// cache gate. Do not fall through to a provider redownload if a later
+		// local read races or fails; keep the already-verified cache truthful.
+		return nil
+	}
+	quality := assessASSCueQuality(raw)
+	return &quality
+}
+
+func copyVerifiedRawASSCheckpoint(entry *indexEpisode, prior indexEpisode) {
+	entry.Status = indexStatusSubtitleCached
+	entry.SubtitleFile = prior.SubtitleFile
+	entry.SubtitleSHA256 = prior.SubtitleSHA256
+	entry.SubtitleParserVersion = rawASSParserVersion
+	entry.SubtitleLangs = prior.SubtitleLangs
+	entry.SubtitleCueQuality = cueQualityForVerifiedRawASS(prior)
+	entry.SubtitleCheckedSourceVersion = checkedSourceVersion(prior)
+	if entry.SubtitleCheckedSourceVersion == "" {
+		entry.SubtitleCheckedSourceVersion = entry.SourceVersion
+	}
+}
+
+func checkedSourceVersion(entry indexEpisode) string {
+	if entry.SubtitleCheckedSourceVersion != "" {
+		return entry.SubtitleCheckedSourceVersion
+	}
+	return entry.SourceVersion
 }
 
 func indexFilename(seriesTitle, contentID string) string {
@@ -250,6 +399,21 @@ type subtitleFetchResult struct {
 	ProviderApplicationCode string
 	RetryAfter              string
 	RateLimit               ProviderRateLimitHeaders
+}
+
+func hasDirectRateLimitEvidence(httpStatus int, retryAfter string, rateLimit ProviderRateLimitHeaders) bool {
+	if httpStatus == 429 || strings.TrimSpace(retryAfter) != "" {
+		return true
+	}
+	return strings.TrimSpace(rateLimit.Remaining) == "0" &&
+		(strings.TrimSpace(rateLimit.Limit) != "" || strings.TrimSpace(rateLimit.Reset) != "")
+}
+
+func providerRestrictionEvidence(httpStatus int, retryAfter string, rateLimit ProviderRateLimitHeaders) string {
+	if hasDirectRateLimitEvidence(httpStatus, retryAfter, rateLimit) {
+		return providerRestrictionRateLimited
+	}
+	return providerRestrictionUnknown
 }
 
 // SubtitleLocaleMismatchError is terminal: the provider map key is not
@@ -486,17 +650,15 @@ func newIndexCatalog(seriesTitle, seriesURL, subsLocale string, seasons []Season
 				AudioLangs:     collectAudioLangs(ep),
 				Status:         status,
 				SubtitleLocale: subsLocale,
+				SourceVersion:  episodeSourceVersion(ep),
 			}
 			// Preserve only a locally checksum-verified, exact-locale raw ASS
-			// checkpoint. Missing/failed/stale entries stay pending and will be
-			// retried serially after this complete initial snapshot is durable.
+			// checkpoint. Terminal missing/permanent rows retain their outcome
+			// until the bounded source/snapshot recheck policy explicitly promotes
+			// a sparse subset back to pending.
 			if fetchSubs && canResumeRawASS(prior[indexEpisodeKey(ep.ID)], subsLocale) {
 				cached := prior[indexEpisodeKey(ep.ID)]
-				entry.Status = indexStatusSubtitleCached
-				entry.SubtitleFile = cached.SubtitleFile
-				entry.SubtitleSHA256 = cached.SubtitleSHA256
-				entry.SubtitleParserVersion = cached.SubtitleParserVersion
-				entry.SubtitleLangs = cached.SubtitleLangs
+				copyVerifiedRawASSCheckpoint(&entry, cached)
 				entry.SubtitleAttemptCount = cached.SubtitleAttemptCount
 				entry.SubtitleFetchAttemptCount = cached.SubtitleFetchAttemptCount
 				entry.StreamReleaseAttemptCount = cached.StreamReleaseAttemptCount
@@ -514,12 +676,15 @@ func newIndexCatalog(seriesTitle, seriesURL, subsLocale string, seasons []Season
 					entry.RetryAfter = priorEntry.RetryAfter
 					entry.RateLimit = priorEntry.RateLimit
 					entry.StreamReleaseOutcome = priorEntry.StreamReleaseOutcome
+					entry.ProviderRestriction = priorEntry.ProviderRestriction
+					entry.SubtitleCheckedSourceVersion = checkedSourceVersion(priorEntry)
+					entry.SubtitleRecheckSnapshot = priorEntry.SubtitleRecheckSnapshot
+					entry.SubtitleRecheckReason = priorEntry.SubtitleRecheckReason
+					entry.SubtitleCueQuality = copyCueQuality(priorEntry.SubtitleCueQuality)
 					entry.Error = priorEntry.Error
-					switch priorEntry.Status {
-					case "subtitle_failed":
-						entry.Status = indexStatusRetryableFailed
-					case indexStatusSubtitleMissing, indexStatusRetryableFailed, indexStatusPermanentFailed, indexStatusThrottled:
-						entry.Status = priorEntry.Status
+					switch normalizeIndexStatus(priorEntry.Status) {
+					case indexStatusSubtitleMissing, indexStatusRetryableFailed, indexStatusPermanentFailed, indexStatusUnknownProviderPlaybackRestriction, indexStatusProviderRateLimited:
+						entry.Status = normalizeIndexStatus(priorEntry.Status)
 					}
 				}
 			}
@@ -527,11 +692,59 @@ func newIndexCatalog(seriesTitle, seriesURL, subsLocale string, seasons []Season
 			work = append(work, indexEpisodeWork{SeasonIndex: seasonIndex, EpisodeIndex: len(catalog.Seasons[seasonIndex].Episodes) - 1, Episode: ep})
 		}
 	}
+	catalog.CatalogSnapshot = catalogSnapshot(catalog)
 	return catalog, work
 }
 
 func replaceCatalogEpisode(catalog *indexFile, work indexEpisodeWork, entry indexEpisode) {
 	catalog.Seasons[work.SeasonIndex].Episodes[work.EpisodeIndex] = entry
+}
+
+func isSparseRecheckTerminalStatus(status string) bool {
+	return status == indexStatusSubtitleMissing || status == indexStatusPermanentFailed
+}
+
+// scheduleSparseTerminalRechecks promotes only a small, deterministic subset
+// of missing-locale/permanent rows back to pending. The caller's priority and
+// newest-first traversal order is authoritative across reason classes. The
+// separately persisted checked source version keeps any source change that
+// misses this run's quota eligible on a later run.
+func scheduleSparseTerminalRechecks(catalog *indexFile, work []indexEpisodeWork, prior map[string]indexEpisode, previousSnapshot string, limit int) int {
+	if limit <= 0 || catalog.CatalogSnapshot == "" {
+		return 0
+	}
+	scheduled := 0
+	for _, item := range work {
+		if scheduled >= limit {
+			break
+		}
+		entry := catalog.Seasons[item.SeasonIndex].Episodes[item.EpisodeIndex]
+		if !isSparseRecheckTerminalStatus(entry.Status) {
+			continue
+		}
+		priorEntry, ok := prior[indexEpisodeKey(item.Episode.ID)]
+		if !ok || priorEntry.SubtitleLocale != entry.SubtitleLocale {
+			continue
+		}
+
+		reason := ""
+		checkedVersion := checkedSourceVersion(priorEntry)
+		if checkedVersion == "" || checkedVersion != entry.SourceVersion {
+			reason = "source_version_changed"
+		} else if previousSnapshot != "" && previousSnapshot != catalog.CatalogSnapshot && priorEntry.SubtitleRecheckSnapshot != catalog.CatalogSnapshot {
+			reason = "catalog_snapshot_changed"
+		}
+		if reason == "" {
+			continue
+		}
+
+		entry.Status = indexStatusPending
+		entry.SubtitleNextEligibleAt = ""
+		entry.SubtitleRecheckReason = reason
+		replaceCatalogEpisode(catalog, item, entry)
+		scheduled++
+	}
+	return scheduled
 }
 
 // writeIndex creates a serial, resumable metadata/subtitle index. Legacy .txt
@@ -594,6 +807,11 @@ func writeIndexWithLoaders(seriesURL, contentID, primaryAudio, primarySubs strin
 		if err != nil {
 			return err
 		}
+		recheckWindow := *indexTerminalRecheckWindow
+		if recheckWindow > *indexWindow {
+			recheckWindow = *indexWindow
+		}
+		scheduleSparseTerminalRechecks(&catalog, work, prior, previous.CatalogSnapshot, recheckWindow)
 	}
 	if err := snapshotIndex(indexPath, &catalog); err != nil {
 		return fmt.Errorf("cannot write initial index %s: %w", indexPath, err)
@@ -651,6 +869,9 @@ func processIndexWork(catalog *indexFile, work []indexEpisodeWork, prior map[str
 	for _, item := range work {
 		entry := catalog.Seasons[item.SeasonIndex].Episodes[item.EpisodeIndex]
 		entry, needsDelay := checkpointSubtitleWithFetcher(item.Episode, entry, locale, subsDir, prior[indexEpisodeKey(item.Episode.ID)], fetch)
+		if needsDelay && entry.SubtitleRecheckReason != "" && catalog.CatalogSnapshot != "" {
+			entry.SubtitleRecheckSnapshot = catalog.CatalogSnapshot
+		}
 		replaceCatalogEpisode(catalog, item, entry)
 		if err := snapshot(catalog); err != nil {
 			return err
@@ -682,11 +903,7 @@ func indexPlayback4294Retries() int {
 func checkpointSubtitleWithFetcher(ep SeasonEpisode, entry indexEpisode, locale, subsDir string, prior indexEpisode, fetch subtitleFetcher) (indexEpisode, bool) {
 	entry.SubtitleLocale = locale
 	if canResumeRawASS(prior, locale) {
-		entry.Status = indexStatusSubtitleCached
-		entry.SubtitleFile = prior.SubtitleFile
-		entry.SubtitleSHA256 = prior.SubtitleSHA256
-		entry.SubtitleParserVersion = rawASSParserVersion
-		entry.SubtitleLangs = prior.SubtitleLangs
+		copyVerifiedRawASSCheckpoint(&entry, prior)
 		return entry, false
 	}
 
@@ -707,6 +924,8 @@ func checkpointSubtitleWithFetcher(ep SeasonEpisode, entry indexEpisode, locale,
 	entry.ProviderApplicationCode = result.ProviderApplicationCode
 	entry.RetryAfter = result.RetryAfter
 	entry.RateLimit = result.RateLimit
+	entry.ProviderRestriction = ""
+	entry.SubtitleCheckedSourceVersion = entry.SourceVersion
 	if err != nil {
 		var missing *SubtitleLocaleError
 		var mismatch *SubtitleLocaleMismatchError
@@ -728,7 +947,15 @@ func checkpointSubtitleWithFetcher(ep SeasonEpisode, entry indexEpisode, locale,
 		} else if errors.As(err, &mismatch) {
 			entry.Status = indexStatusPermanentFailed
 		} else if errors.As(err, &playbackErr) && playbackErr.Code == playback4294Code {
-			entry.Status = indexStatusThrottled
+			entry.ProviderRestriction = providerRestrictionEvidence(entry.HTTPStatus, entry.RetryAfter, entry.RateLimit)
+			if entry.ProviderRestriction == providerRestrictionRateLimited {
+				entry.Status = indexStatusProviderRateLimited
+			} else {
+				entry.Status = indexStatusUnknownProviderPlaybackRestriction
+			}
+		} else if errors.As(err, &httpErr) && hasDirectRateLimitEvidence(entry.HTTPStatus, entry.RetryAfter, entry.RateLimit) {
+			entry.ProviderRestriction = providerRestrictionRateLimited
+			entry.Status = indexStatusProviderRateLimited
 		} else if errors.As(err, &httpErr) && httpErr.StatusCode >= 400 && httpErr.StatusCode < 500 && httpErr.StatusCode != 408 && httpErr.StatusCode != 429 {
 			entry.Status = indexStatusPermanentFailed
 		} else {
@@ -749,6 +976,9 @@ func checkpointSubtitleWithFetcher(ep SeasonEpisode, entry indexEpisode, locale,
 	entry.SubtitleFile = relativePath // Link it in the checkpoint immediately.
 	entry.SubtitleSHA256 = hex.EncodeToString(sum[:])
 	entry.SubtitleParserVersion = rawASSParserVersion
+	quality := assessASSCueQuality(result.RawASS)
+	entry.SubtitleCueQuality = &quality
+	entry.Error = ""
 	return entry, true
 }
 
@@ -761,7 +991,31 @@ var (
 )
 
 func parseASS(data []byte) string {
+	transcript, _ := parseASSWithCueQuality(data)
+	return transcript
+}
+
+func newASSCueQuality() subtitleCueQuality {
+	return subtitleCueQuality{
+		Version:              assCueQualityVersion,
+		MaxMalformedCueRatio: maxMalformedASSCueRatio,
+		MaxEmptyCueRatio:     maxEmptyASSCueRatio,
+		MaxSkippedCueRatio:   maxSkippedASSCueRatio,
+		Outcome:              "healthy",
+	}
+}
+
+// assessASSCueQuality is deliberately local and non-mutating. It can be run
+// against an existing checksum-verified cache without opening playback or
+// downloading the subtitle again.
+func assessASSCueQuality(data []byte) subtitleCueQuality {
+	_, quality := parseASSWithCueQuality(data)
+	return quality
+}
+
+func parseASSWithCueQuality(data []byte) (string, subtitleCueQuality) {
 	var output strings.Builder
+	quality := newASSCueQuality()
 	inEvents := false
 	var fields []string
 	for _, original := range strings.Split(string(data), "\n") {
@@ -776,23 +1030,50 @@ func parseASS(data []byte) string {
 		if !inEvents {
 			continue
 		}
-		if strings.HasPrefix(line, "Format:") {
-			fields = splitASSFields(strings.TrimSpace(strings.TrimPrefix(line, "Format:")))
+		if strings.HasPrefix(strings.ToLower(line), "format:") {
+			fields = splitASSFields(strings.TrimSpace(line[len("Format:"):]))
 			continue
 		}
-		if !strings.HasPrefix(line, "Dialogue:") {
+		if !strings.HasPrefix(strings.ToLower(line), "dialogue:") {
 			continue
 		}
-		start, text, ok := parseASSDialogue(strings.TrimSpace(strings.TrimPrefix(line, "Dialogue:")), fields)
+		quality.TotalCues++
+		start, text, ok := parseASSDialogue(strings.TrimSpace(line[len("Dialogue:"):]), fields)
 		if !ok {
+			quality.MalformedCues++
 			continue
 		}
 		text = strings.TrimSpace(assNewlineRe.ReplaceAllString(assOverrideRe.ReplaceAllString(text, ""), " "))
-		if text != "" {
-			fmt.Fprintf(&output, "[%s] %s\n", formatASSTimestamp(start), text)
+		if text == "" {
+			quality.EmptyCues++
+			continue
 		}
+		formattedStart, validStart := formatASSTimestampChecked(start)
+		if !validStart {
+			quality.SkippedCues++
+			continue
+		}
+		quality.UsableCues++
+		fmt.Fprintf(&output, "[%s] %s\n", formattedStart, text)
 	}
-	return output.String()
+	quality.Outcome = cueQualityOutcome(quality)
+	return output.String(), quality
+}
+
+func cueQualityOutcome(quality subtitleCueQuality) string {
+	if quality.TotalCues == 0 || quality.UsableCues == 0 {
+		return "degraded"
+	}
+	if exceedsCueQualityRatio(quality.MalformedCues, quality.TotalCues, quality.MaxMalformedCueRatio) ||
+		exceedsCueQualityRatio(quality.EmptyCues, quality.TotalCues, quality.MaxEmptyCueRatio) ||
+		exceedsCueQualityRatio(quality.SkippedCues, quality.TotalCues, quality.MaxSkippedCueRatio) {
+		return "degraded"
+	}
+	return "healthy"
+}
+
+func exceedsCueQualityRatio(count, total int, maximum float64) bool {
+	return total > 0 && float64(count)/float64(total) > maximum
 }
 
 func splitASSFields(format string) []string {
@@ -830,19 +1111,36 @@ func parseASSDialogue(payload string, fields []string) (start, text string, ok b
 }
 
 func formatASSTimestamp(value string) string {
+	formatted, ok := formatASSTimestampChecked(value)
+	if !ok {
+		return "00:00:00"
+	}
+	return formatted
+}
+
+func formatASSTimestampChecked(value string) (string, bool) {
 	value = strings.TrimSpace(value)
 	if dot := strings.IndexByte(value, '.'); dot >= 0 {
+		fraction := value[dot+1:]
+		if fraction == "" {
+			return "", false
+		}
+		for _, digit := range fraction {
+			if digit < '0' || digit > '9' {
+				return "", false
+			}
+		}
 		value = value[:dot]
 	}
 	parts := strings.Split(value, ":")
 	if len(parts) != 3 {
-		return "00:00:00"
+		return "", false
 	}
 	hour, errHour := strconv.Atoi(parts[0])
 	minute, errMinute := strconv.Atoi(parts[1])
 	second, errSecond := strconv.Atoi(parts[2])
-	if errHour != nil || errMinute != nil || errSecond != nil || hour < 0 || minute < 0 || second < 0 {
-		return "00:00:00"
+	if errHour != nil || errMinute != nil || errSecond != nil || hour < 0 || minute < 0 || minute >= 60 || second < 0 || second >= 60 {
+		return "", false
 	}
-	return fmt.Sprintf("%02d:%02d:%02d", hour, minute, second)
+	return fmt.Sprintf("%02d:%02d:%02d", hour, minute, second), true
 }

--- a/index.go
+++ b/index.go
@@ -24,18 +24,37 @@ const (
 	indexStatusPending         = "pending"
 	indexStatusIndexed         = "indexed"
 	indexStatusSubtitleCached  = "subtitle_cached"
-	indexStatusSubtitleMissing = "subtitle_missing"
-	indexStatusSubtitleFailed  = "subtitle_failed"
+	indexStatusSubtitleMissing = "subtitle_missing_locale"
+	indexStatusRetryableFailed = "subtitle_retryable_failed"
+	indexStatusPermanentFailed = "subtitle_permanent_failed"
+	indexStatusThrottled       = "subtitle_throttled"
+	// Deprecated source alias retained for older focused tests and callers;
+	// serialized checkpoints use the typed retryable value above.
+	indexStatusSubtitleFailed = indexStatusRetryableFailed
 )
 
 // indexFile is a durable, self-contained checkpoint. Every terminal episode
 // state is followed by an atomic rewrite of this full snapshot.
 type indexFile struct {
-	Series    string        `json:"series"`
-	SeriesURL string        `json:"series_url"`
-	IndexedAt string        `json:"indexed_at"`
-	SubsLang  string        `json:"subs_lang,omitempty"`
-	Seasons   []indexSeason `json:"seasons"`
+	Series     string          `json:"series"`
+	SeriesURL  string          `json:"series_url"`
+	IndexedAt  string          `json:"indexed_at"`
+	SubsLang   string          `json:"subs_lang,omitempty"`
+	Seasons    []indexSeason   `json:"seasons"`
+	Checkpoint indexCheckpoint `json:"checkpoint,omitempty"`
+}
+
+type indexCheckpoint struct {
+	CursorProviderID string            `json:"cursor_provider_id,omitempty"`
+	UpdatedAt        string            `json:"updated_at,omitempty"`
+	Circuit          indexCircuitState `json:"circuit"`
+}
+
+type indexCircuitState struct {
+	State                 string `json:"state"`
+	Consecutive4294       int    `json:"consecutive_4294"`
+	OpenedAt              string `json:"opened_at,omitempty"`
+	NextEligibleAttemptAt string `json:"next_eligible_attempt_at,omitempty"`
 }
 
 type indexSeason struct {
@@ -44,20 +63,30 @@ type indexSeason struct {
 }
 
 type indexEpisode struct {
-	Episode               int      `json:"episode"`
-	Title                 string   `json:"title"`
-	Description           string   `json:"description,omitempty"`
-	ID                    string   `json:"id"`
-	URL                   string   `json:"url"`
-	AirDate               string   `json:"air_date,omitempty"`
-	AudioLangs            []string `json:"audio_langs,omitempty"`
-	SubtitleLangs         []string `json:"subtitle_langs,omitempty"`
-	Status                string   `json:"status"`
-	SubtitleFile          string   `json:"subtitle_file,omitempty"`
-	SubtitleLocale        string   `json:"subtitle_locale,omitempty"`
-	SubtitleSHA256        string   `json:"subtitle_sha256,omitempty"`
-	SubtitleParserVersion string   `json:"subtitle_parser_version,omitempty"`
-	Error                 string   `json:"error,omitempty"`
+	Episode                   int                      `json:"episode"`
+	Title                     string                   `json:"title"`
+	Description               string                   `json:"description,omitempty"`
+	ID                        string                   `json:"id"`
+	URL                       string                   `json:"url"`
+	AirDate                   string                   `json:"air_date,omitempty"`
+	AudioLangs                []string                 `json:"audio_langs,omitempty"`
+	SubtitleLangs             []string                 `json:"subtitle_langs,omitempty"`
+	Status                    string                   `json:"status"`
+	SubtitleFile              string                   `json:"subtitle_file,omitempty"`
+	SubtitleLocale            string                   `json:"subtitle_locale,omitempty"`
+	SubtitleSHA256            string                   `json:"subtitle_sha256,omitempty"`
+	SubtitleParserVersion     string                   `json:"subtitle_parser_version,omitempty"`
+	SubtitleAttemptCount      int                      `json:"subtitle_attempt_count,omitempty"`
+	SubtitleFetchAttemptCount int                      `json:"subtitle_fetch_attempt_count,omitempty"`
+	StreamReleaseAttemptCount int                      `json:"stream_release_attempt_count,omitempty"`
+	SubtitleLastAttemptAt     string                   `json:"subtitle_last_attempt_at,omitempty"`
+	SubtitleNextEligibleAt    string                   `json:"subtitle_next_eligible_at,omitempty"`
+	HTTPStatus                int                      `json:"http_status,omitempty"`
+	ProviderApplicationCode   string                   `json:"provider_application_code,omitempty"`
+	RetryAfter                string                   `json:"retry_after,omitempty"`
+	RateLimit                 ProviderRateLimitHeaders `json:"rate_limit,omitempty"`
+	StreamReleaseOutcome      string                   `json:"stream_release_outcome,omitempty"`
+	Error                     string                   `json:"error,omitempty"`
 }
 
 func (episode indexEpisode) isVerifiedRawASS() bool {
@@ -211,8 +240,16 @@ func sortedSubtitleLocales(subtitles map[string]*Subtitle) []string {
 }
 
 type subtitleFetchResult struct {
-	AvailableLangs []string
-	RawASS         []byte
+	AvailableLangs          []string
+	RawASS                  []byte
+	PlaybackAttempts        int
+	SubtitleFetchAttempts   int
+	StreamReleaseAttempts   int
+	StreamReleaseOutcome    string
+	HTTPStatus              int
+	ProviderApplicationCode string
+	RetryAfter              string
+	RateLimit               ProviderRateLimitHeaders
 }
 
 // SubtitleLocaleMismatchError is terminal: the provider map key is not
@@ -248,10 +285,17 @@ func fetchSubtitles(episodeID, locale string) (result subtitleFetchResult, err e
 	if err := func() (err error) {
 		defer func() {
 			if recovered := recover(); recovered != nil {
-				err = fmt.Errorf("open playback for %s: %v", episodeID, recovered)
+				if recoveredErr, ok := recovered.(error); ok {
+					err = fmt.Errorf("open playback for %s: %w", episodeID, recoveredErr)
+				} else {
+					err = fmt.Errorf("open playback for %s: %v", episodeID, recovered)
+				}
 			}
 		}()
-		episode = openPlaybackWithRetry(episodeID, openIndexPlayback, *playback4294Retries, *playback4294Backoff, sleepPlaybackRetry)
+		episode = openPlaybackWithRetry(episodeID, func(id string) Episode {
+			result.PlaybackAttempts++
+			return openIndexPlayback(id)
+		}, indexPlayback4294Retries(), *playback4294Backoff, sleepPlaybackRetry)
 		return nil
 	}(); err != nil {
 		return result, err
@@ -264,8 +308,16 @@ func fetchSubtitles(episodeID, locale string) (result subtitleFetchResult, err e
 			var recovered any
 			func() {
 				defer func() { recovered = recover() }()
+				result.StreamReleaseAttempts++
 				released = deleteStream(episodeID, episode.Token)
 			}()
+			if recovered != nil {
+				result.StreamReleaseOutcome = "failed"
+			} else if released {
+				result.StreamReleaseOutcome = "released"
+			} else {
+				result.StreamReleaseOutcome = "not_released"
+			}
 			if err == nil && recovered != nil {
 				err = fmt.Errorf("release playback stream for %s: %v", episodeID, recovered)
 			} else if err == nil && !released {
@@ -283,6 +335,7 @@ func fetchSubtitles(episodeID, locale string) (result subtitleFetchResult, err e
 		return result, err
 	}
 	raw, err := fetchSubtitleASS(subtitle.URL)
+	result.SubtitleFetchAttempts++
 	if err != nil {
 		return result, err
 	}
@@ -304,6 +357,29 @@ type indexEpisodeWork struct {
 	SeasonIndex  int
 	EpisodeIndex int
 	Episode      SeasonEpisode
+}
+
+// sortIndexWorkNewestFirst returns a deterministic traversal plan without
+// changing catalog presentation order. Provider availability time is the
+// canonical newest signal; season and episode numbers break equal-date ties,
+// and provider episode ID makes duplicate-number variants collision-stable.
+func sortIndexWorkNewestFirst(work []indexEpisodeWork) []indexEpisodeWork {
+	ordered := append([]indexEpisodeWork(nil), work...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left := ordered[i].Episode
+		right := ordered[j].Episode
+		if left.AvailabilityStarts != right.AvailabilityStarts {
+			return left.AvailabilityStarts > right.AvailabilityStarts
+		}
+		if left.SeasonNumber != right.SeasonNumber {
+			return left.SeasonNumber > right.SeasonNumber
+		}
+		if left.EpisodeNumber != right.EpisodeNumber {
+			return left.EpisodeNumber > right.EpisodeNumber
+		}
+		return left.ID < right.ID
+	})
+	return ordered
 }
 
 // parseIndexPriorityIDs normalizes the comma-separated CLI value while
@@ -384,10 +460,11 @@ func reorderIndexWork(work []indexEpisodeWork, priorityIDs []string) ([]indexEpi
 // pending so an interrupted run never publishes a misleading processed prefix.
 func newIndexCatalog(seriesTitle, seriesURL, subsLocale string, seasons []Season, seasonEpisodes map[string][]SeasonEpisode, prior map[string]indexEpisode, fetchSubs bool) (indexFile, []indexEpisodeWork) {
 	catalog := indexFile{
-		Series:    seriesTitle,
-		SeriesURL: seriesURL,
-		SubsLang:  subsLocale,
-		Seasons:   make([]indexSeason, 0, len(seasons)),
+		Series:     seriesTitle,
+		SeriesURL:  seriesURL,
+		SubsLang:   subsLocale,
+		Seasons:    make([]indexSeason, 0, len(seasons)),
+		Checkpoint: indexCheckpoint{Circuit: indexCircuitState{State: "closed"}},
 	}
 	work := make([]indexEpisodeWork, 0)
 	for _, season := range seasons {
@@ -420,6 +497,31 @@ func newIndexCatalog(seriesTitle, seriesURL, subsLocale string, seasons []Season
 				entry.SubtitleSHA256 = cached.SubtitleSHA256
 				entry.SubtitleParserVersion = cached.SubtitleParserVersion
 				entry.SubtitleLangs = cached.SubtitleLangs
+				entry.SubtitleAttemptCount = cached.SubtitleAttemptCount
+				entry.SubtitleFetchAttemptCount = cached.SubtitleFetchAttemptCount
+				entry.StreamReleaseAttemptCount = cached.StreamReleaseAttemptCount
+				entry.SubtitleLastAttemptAt = cached.SubtitleLastAttemptAt
+			} else if fetchSubs {
+				priorEntry := prior[indexEpisodeKey(ep.ID)]
+				if priorEntry.SubtitleLocale == subsLocale {
+					entry.SubtitleAttemptCount = priorEntry.SubtitleAttemptCount
+					entry.SubtitleFetchAttemptCount = priorEntry.SubtitleFetchAttemptCount
+					entry.StreamReleaseAttemptCount = priorEntry.StreamReleaseAttemptCount
+					entry.SubtitleLastAttemptAt = priorEntry.SubtitleLastAttemptAt
+					entry.SubtitleNextEligibleAt = priorEntry.SubtitleNextEligibleAt
+					entry.HTTPStatus = priorEntry.HTTPStatus
+					entry.ProviderApplicationCode = priorEntry.ProviderApplicationCode
+					entry.RetryAfter = priorEntry.RetryAfter
+					entry.RateLimit = priorEntry.RateLimit
+					entry.StreamReleaseOutcome = priorEntry.StreamReleaseOutcome
+					entry.Error = priorEntry.Error
+					switch priorEntry.Status {
+					case "subtitle_failed":
+						entry.Status = indexStatusRetryableFailed
+					case indexStatusSubtitleMissing, indexStatusRetryableFailed, indexStatusPermanentFailed, indexStatusThrottled:
+						entry.Status = priorEntry.Status
+					}
+				}
 			}
 			catalog.Seasons[seasonIndex].Episodes = append(catalog.Seasons[seasonIndex].Episodes, entry)
 			work = append(work, indexEpisodeWork{SeasonIndex: seasonIndex, EpisodeIndex: len(catalog.Seasons[seasonIndex].Episodes) - 1, Episode: ep})
@@ -480,7 +582,12 @@ func writeIndexWithLoaders(seriesURL, contentID, primaryAudio, primarySubs strin
 	}
 	prior := priorEpisodes(previous)
 	catalog, work := newIndexCatalog(seriesTitle, seriesURL, primarySubs, seasons, seasonEpisodes, prior, fetchSubs)
+	catalog.Checkpoint = previous.Checkpoint
+	if catalog.Checkpoint.Circuit.State == "" {
+		catalog.Checkpoint.Circuit.State = "closed"
+	}
 	if fetchSubs {
+		work = sortIndexWorkNewestFirst(work)
 		priorityIDs := parseIndexPriorityIDs(*indexPriority)
 		var err error
 		work, err = reorderIndexWork(work, priorityIDs)
@@ -505,27 +612,53 @@ func writeIndexWithLoaders(seriesURL, contentID, primaryAudio, primarySubs strin
 		return fmt.Errorf("cannot create subtitle directory %s: %w", subsDir, err)
 	}
 
-	for _, item := range work {
-		entry := catalog.Seasons[item.SeasonIndex].Episodes[item.EpisodeIndex]
-		var needsDelay bool
-		entry, needsDelay = checkpointSubtitle(item.Episode, entry, primarySubs, subsDir, prior[indexEpisodeKey(item.Episode.ID)])
-		replaceCatalogEpisode(&catalog, item, entry)
-		// Each terminal state updates the already-complete catalog atomically.
-		if err := snapshotIndex(indexPath, &catalog); err != nil {
-			return fmt.Errorf("cannot checkpoint %s: %w", indexPath, err)
-		}
-		// A checksum-valid raw ASS resume did not touch playback or the
-		// subtitle endpoint. Only actual attempts need the provider pacing delay.
-		if needsDelay {
-			delaySeconds := *indexDelay
-			if delaySeconds < minimumIndexDelaySeconds {
-				delaySeconds = minimumIndexDelaySeconds
-			}
-			time.Sleep(time.Duration(delaySeconds) * time.Second)
-		}
+	delaySeconds := *indexDelay
+	if delaySeconds < minimumIndexDelaySeconds {
+		delaySeconds = minimumIndexDelaySeconds
+	}
+	summaryPath := strings.TrimSpace(*indexSummaryPath)
+	if summaryPath == "" {
+		summaryPath = indexPath + ".run-summary.json"
+	}
+	startedAt := time.Now().UTC()
+	summary, err := processIndexWorkBounded(&catalog, work, prior, primarySubs, subsDir, fetchSubtitles, func(file *indexFile) error {
+		return snapshotIndex(indexPath, file)
+	}, indexRunOptions{
+		Window: *indexWindow, Circuit4294Limit: *indexCircuitLimit,
+		CircuitCooldown: *indexCircuitCooldown,
+		Delay:           time.Duration(delaySeconds) * time.Second, Sleep: time.Sleep,
+		Now: func() time.Time { return time.Now().UTC() }, StartedAt: startedAt,
+		ProviderMetrics: providerCallMetricsSnapshot,
+	})
+	if writeErr := writeIndexRunSummary(summaryPath, summary); writeErr != nil {
+		return fmt.Errorf("cannot write terminal run summary %s: %w", summaryPath, writeErr)
+	}
+	if err != nil {
+		return fmt.Errorf("cannot checkpoint %s: %w", indexPath, err)
 	}
 
 	fmt.Printf("Index written: %s\n", indexPath)
+	return nil
+}
+
+type indexSnapshotter func(*indexFile) error
+
+// processIndexWork is deliberately serial. Each identity reaches a terminal
+// cached/missing/failed state and is durably snapshotted before the next
+// identity is attempted. Fetch failures are record-local and never stop older
+// work; only inability to persist the checkpoint stops traversal.
+func processIndexWork(catalog *indexFile, work []indexEpisodeWork, prior map[string]indexEpisode, locale, subsDir string, fetch subtitleFetcher, snapshot indexSnapshotter, delay time.Duration, sleep playbackSleeper) error {
+	for _, item := range work {
+		entry := catalog.Seasons[item.SeasonIndex].Episodes[item.EpisodeIndex]
+		entry, needsDelay := checkpointSubtitleWithFetcher(item.Episode, entry, locale, subsDir, prior[indexEpisodeKey(item.Episode.ID)], fetch)
+		replaceCatalogEpisode(catalog, item, entry)
+		if err := snapshot(catalog); err != nil {
+			return err
+		}
+		if needsDelay {
+			sleep(delay)
+		}
+	}
 	return nil
 }
 
@@ -539,6 +672,13 @@ func checkpointSubtitle(ep SeasonEpisode, entry indexEpisode, locale, subsDir st
 
 type subtitleFetcher func(string, string) (subtitleFetchResult, error)
 
+func indexPlayback4294Retries() int {
+	// The persisted global circuit owns 4294 recovery during indexing. Retrying
+	// inside one identity would hide consecutive responses from that circuit and
+	// multiply provider calls before the cursor can be checkpointed.
+	return 0
+}
+
 func checkpointSubtitleWithFetcher(ep SeasonEpisode, entry indexEpisode, locale, subsDir string, prior indexEpisode, fetch subtitleFetcher) (indexEpisode, bool) {
 	entry.SubtitleLocale = locale
 	if canResumeRawASS(prior, locale) {
@@ -551,13 +691,48 @@ func checkpointSubtitleWithFetcher(ep SeasonEpisode, entry indexEpisode, locale,
 	}
 
 	result, err := fetch(ep.ID, locale)
+	attempts := result.PlaybackAttempts
+	if attempts < 1 {
+		// Test and alternate fetchers predate playback-attempt telemetry, but a
+		// fetch invocation is still one real acquisition attempt.
+		attempts = 1
+	}
+	entry.SubtitleAttemptCount = prior.SubtitleAttemptCount + attempts
+	entry.SubtitleFetchAttemptCount = prior.SubtitleFetchAttemptCount + result.SubtitleFetchAttempts
+	entry.StreamReleaseAttemptCount = prior.StreamReleaseAttemptCount + result.StreamReleaseAttempts
+	entry.SubtitleLastAttemptAt = time.Now().UTC().Format(time.RFC3339Nano)
 	entry.SubtitleLangs = result.AvailableLangs
+	entry.StreamReleaseOutcome = result.StreamReleaseOutcome
+	entry.HTTPStatus = result.HTTPStatus
+	entry.ProviderApplicationCode = result.ProviderApplicationCode
+	entry.RetryAfter = result.RetryAfter
+	entry.RateLimit = result.RateLimit
 	if err != nil {
 		var missing *SubtitleLocaleError
+		var mismatch *SubtitleLocaleMismatchError
+		var playbackErr *PlaybackAPIError
+		var httpErr *HTTPStatusError
+		if errors.As(err, &playbackErr) {
+			entry.HTTPStatus = playbackErr.HTTPStatus
+			entry.ProviderApplicationCode = playbackErr.Code
+			entry.RetryAfter = playbackErr.RetryAfter
+			entry.RateLimit = playbackErr.RateLimit
+		}
+		if errors.As(err, &httpErr) {
+			entry.HTTPStatus = httpErr.StatusCode
+			entry.RetryAfter = httpErr.RetryAfter
+			entry.RateLimit = httpErr.RateLimit
+		}
 		if errors.As(err, &missing) {
 			entry.Status = indexStatusSubtitleMissing
+		} else if errors.As(err, &mismatch) {
+			entry.Status = indexStatusPermanentFailed
+		} else if errors.As(err, &playbackErr) && playbackErr.Code == playback4294Code {
+			entry.Status = indexStatusThrottled
+		} else if errors.As(err, &httpErr) && httpErr.StatusCode >= 400 && httpErr.StatusCode < 500 && httpErr.StatusCode != 408 && httpErr.StatusCode != 429 {
+			entry.Status = indexStatusPermanentFailed
 		} else {
-			entry.Status = indexStatusSubtitleFailed
+			entry.Status = indexStatusRetryableFailed
 		}
 		entry.Error = redactSensitiveURLs(err.Error())
 		return entry, true

--- a/index.go
+++ b/index.go
@@ -1,0 +1,673 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const rawASSParserVersion = "raw-ass/v1"
+const minimumIndexDelaySeconds = 2
+
+var openIndexPlayback playbackOpener = getEpisode
+
+const (
+	indexStatusPending         = "pending"
+	indexStatusIndexed         = "indexed"
+	indexStatusSubtitleCached  = "subtitle_cached"
+	indexStatusSubtitleMissing = "subtitle_missing"
+	indexStatusSubtitleFailed  = "subtitle_failed"
+)
+
+// indexFile is a durable, self-contained checkpoint. Every terminal episode
+// state is followed by an atomic rewrite of this full snapshot.
+type indexFile struct {
+	Series    string        `json:"series"`
+	SeriesURL string        `json:"series_url"`
+	IndexedAt string        `json:"indexed_at"`
+	SubsLang  string        `json:"subs_lang,omitempty"`
+	Seasons   []indexSeason `json:"seasons"`
+}
+
+type indexSeason struct {
+	Season   int            `json:"season"`
+	Episodes []indexEpisode `json:"episodes"`
+}
+
+type indexEpisode struct {
+	Episode               int      `json:"episode"`
+	Title                 string   `json:"title"`
+	Description           string   `json:"description,omitempty"`
+	ID                    string   `json:"id"`
+	URL                   string   `json:"url"`
+	AirDate               string   `json:"air_date,omitempty"`
+	AudioLangs            []string `json:"audio_langs,omitempty"`
+	SubtitleLangs         []string `json:"subtitle_langs,omitempty"`
+	Status                string   `json:"status"`
+	SubtitleFile          string   `json:"subtitle_file,omitempty"`
+	SubtitleLocale        string   `json:"subtitle_locale,omitempty"`
+	SubtitleSHA256        string   `json:"subtitle_sha256,omitempty"`
+	SubtitleParserVersion string   `json:"subtitle_parser_version,omitempty"`
+	Error                 string   `json:"error,omitempty"`
+}
+
+func (episode indexEpisode) isVerifiedRawASS() bool {
+	return episode.Status == indexStatusSubtitleCached &&
+		episode.SubtitleFile != "" &&
+		episode.SubtitleLocale != "" &&
+		episode.SubtitleSHA256 != "" &&
+		episode.SubtitleParserVersion == rawASSParserVersion
+}
+
+func indexFilename(seriesTitle, contentID string) string {
+	if strings.TrimSpace(seriesTitle) == "" {
+		seriesTitle = contentID
+	}
+	return sanitize(seriesTitle) + "_index.json"
+}
+
+func indexEpisodeKey(id string) string { return id }
+
+func priorEpisodes(file indexFile) map[string]indexEpisode {
+	prior := make(map[string]indexEpisode)
+	for _, season := range file.Seasons {
+		for _, episode := range season.Episodes {
+			if episode.ID != "" {
+				prior[indexEpisodeKey(episode.ID)] = episode
+			}
+		}
+	}
+	return prior
+}
+
+func loadIndex(path string) (indexFile, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return indexFile{}, nil
+	}
+	if err != nil {
+		return indexFile{}, fmt.Errorf("read index %s: %w", path, err)
+	}
+	var file indexFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return indexFile{}, fmt.Errorf("parse index %s: %w", path, err)
+	}
+	return file, nil
+}
+
+func marshalIndex(file indexFile) ([]byte, error) {
+	return json.MarshalIndent(file, "", "  ")
+}
+
+// atomicWriteFile writes and fsyncs a same-directory temporary file before a
+// rename, so an interrupted run keeps either the old complete checkpoint or
+// the new complete checkpoint -- never a partial JSON/ASS file.
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	tmp, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary file next to %s: %w", path, err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		cleanup()
+		return fmt.Errorf("set temporary file mode: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return fmt.Errorf("write temporary file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("sync temporary file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("close temporary file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("atomically replace %s: %w", path, err)
+	}
+	if directory, err := os.Open(dir); err == nil {
+		_ = directory.Sync()
+		_ = directory.Close()
+	}
+	return nil
+}
+
+func snapshotIndex(path string, file *indexFile) error {
+	file.IndexedAt = time.Now().UTC().Format(time.RFC3339)
+	data, err := marshalIndex(*file)
+	if err != nil {
+		return fmt.Errorf("marshal index: %w", err)
+	}
+	return atomicWriteFile(path, data, 0644)
+}
+
+func sha256File(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func canResumeRawASS(prior indexEpisode, locale string) bool {
+	if !prior.isVerifiedRawASS() || prior.SubtitleLocale != locale {
+		return false
+	}
+	checksum, err := sha256File(prior.SubtitleFile)
+	return err == nil && checksum == prior.SubtitleSHA256
+}
+
+func rawASSPath(subsDir string, season, episode int, episodeID string) string {
+	return filepath.Join(subsDir, fmt.Sprintf("S%02dE%03d_%s.ass", season, episode, sanitize(episodeID)))
+}
+
+func collectAudioLangs(ep SeasonEpisode) []string {
+	seen := map[string]bool{}
+	var langs []string
+	add := func(locale string) {
+		if locale != "" && !seen[locale] {
+			seen[locale] = true
+			langs = append(langs, locale)
+		}
+	}
+	add(ep.AudioLocale)
+	for _, version := range ep.Versions {
+		if version != nil {
+			add(version.AudioLocale)
+		}
+	}
+	sort.Strings(langs)
+	return langs
+}
+
+func sortedSubtitleLocales(subtitles map[string]*Subtitle) []string {
+	locales := make([]string, 0, len(subtitles))
+	for locale, subtitle := range subtitles {
+		if subtitle != nil && subtitle.URL != "" {
+			locales = append(locales, locale)
+		}
+	}
+	sort.Strings(locales)
+	return locales
+}
+
+type subtitleFetchResult struct {
+	AvailableLangs []string
+	RawASS         []byte
+}
+
+// SubtitleLocaleMismatchError is terminal: the provider map key is not
+// enough to prove that the returned subtitle track has the requested locale.
+type SubtitleLocaleMismatchError struct {
+	Requested string
+	Actual    string
+}
+
+func (e *SubtitleLocaleMismatchError) Error() string {
+	return fmt.Sprintf("subtitle locale mismatch: requested %s, received %s", e.Requested, e.Actual)
+}
+
+func exactSubtitleForLocale(subtitles map[string]*Subtitle, locale string) (*Subtitle, error) {
+	subtitle, ok := subtitles[locale]
+	if !ok || subtitle == nil || subtitle.URL == "" {
+		return nil, &SubtitleLocaleError{Locale: locale}
+	}
+	if subtitle.Language != locale {
+		return nil, &SubtitleLocaleMismatchError{Requested: locale, Actual: subtitle.Language}
+	}
+	return subtitle, nil
+}
+
+// fetchSubtitles uses the exact requested locale. A different locale is never
+// silently substituted: that would make a checkpoint claim a transcript it
+// did not actually fetch. Playback streams are released before returning.
+func fetchSubtitles(episodeID, locale string) (result subtitleFetchResult, err error) {
+	if locale == "" {
+		return result, fmt.Errorf("subtitle locale is required")
+	}
+	var episode Episode
+	if err := func() (err error) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				err = fmt.Errorf("open playback for %s: %v", episodeID, recovered)
+			}
+		}()
+		episode = openPlaybackWithRetry(episodeID, openIndexPlayback, *playback4294Retries, *playback4294Backoff, sleepPlaybackRetry)
+		return nil
+	}(); err != nil {
+		return result, err
+	}
+
+	result.AvailableLangs = sortedSubtitleLocales(episode.Subtitles)
+	if episode.Token != "" {
+		defer func() {
+			var released bool
+			var recovered any
+			func() {
+				defer func() { recovered = recover() }()
+				released = deleteStream(episodeID, episode.Token)
+			}()
+			if err == nil && recovered != nil {
+				err = fmt.Errorf("release playback stream for %s: %v", episodeID, recovered)
+			} else if err == nil && !released {
+				err = fmt.Errorf("release playback stream for %s", episodeID)
+			}
+		}()
+	}
+
+	subtitle, err := exactSubtitleForLocale(episode.Subtitles, locale)
+	if err != nil {
+		var missing *SubtitleLocaleError
+		if errors.As(err, &missing) {
+			missing.EpisodeID = episodeID
+		}
+		return result, err
+	}
+	raw, err := fetchSubtitleASS(subtitle.URL)
+	if err != nil {
+		return result, err
+	}
+	result.RawASS = raw
+	return result, nil
+}
+
+// SubtitleLocaleError records exact-locale absence as a normal terminal state.
+type SubtitleLocaleError struct {
+	EpisodeID string
+	Locale    string
+}
+
+func (e *SubtitleLocaleError) Error() string {
+	return fmt.Sprintf("subtitle locale %s is not available for episode %s", e.Locale, e.EpisodeID)
+}
+
+type indexEpisodeWork struct {
+	SeasonIndex  int
+	EpisodeIndex int
+	Episode      SeasonEpisode
+}
+
+// parseIndexPriorityIDs normalizes the comma-separated CLI value while
+// preserving the user's first-declared order. Empty entries and duplicates do
+// not add work or alter the existing episode list.
+func parseIndexPriorityIDs(value string) []string {
+	seen := make(map[string]struct{})
+	var ids []string
+	for _, raw := range strings.Split(value, ",") {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// IndexPriorityIDsError reports every requested ID that was not present in
+// the discovered provider episode list, in deterministic declaration order.
+type IndexPriorityIDsError struct {
+	Unknown []string
+}
+
+func (e *IndexPriorityIDsError) Error() string {
+	return fmt.Sprintf("unknown --index-priority-ids episode ID(s): %s", strings.Join(e.Unknown, ", "))
+}
+
+// reorderIndexWork moves requested IDs to the front in declaration order and
+// leaves all other work items in their original order. It never filters work;
+// duplicate provider IDs in the discovered list are all retained and moved as
+// one group. Unknown requested IDs are rejected before any playback attempt.
+func reorderIndexWork(work []indexEpisodeWork, priorityIDs []string) ([]indexEpisodeWork, error) {
+	if len(priorityIDs) == 0 {
+		return append([]indexEpisodeWork(nil), work...), nil
+	}
+
+	positionsByID := make(map[string][]int, len(work))
+	for position, item := range work {
+		positionsByID[item.Episode.ID] = append(positionsByID[item.Episode.ID], position)
+	}
+	unknown := make([]string, 0)
+	used := make([]bool, len(work))
+	reordered := make([]indexEpisodeWork, 0, len(work))
+	seenPriority := make(map[string]struct{}, len(priorityIDs))
+	for _, id := range priorityIDs {
+		if _, seen := seenPriority[id]; seen {
+			continue
+		}
+		seenPriority[id] = struct{}{}
+		positions, ok := positionsByID[id]
+		if !ok {
+			unknown = append(unknown, id)
+			continue
+		}
+		for _, position := range positions {
+			reordered = append(reordered, work[position])
+			used[position] = true
+		}
+	}
+	if len(unknown) > 0 {
+		return nil, &IndexPriorityIDsError{Unknown: unknown}
+	}
+	for position, item := range work {
+		if !used[position] {
+			reordered = append(reordered, item)
+		}
+	}
+	return reordered, nil
+}
+
+// newIndexCatalog creates the complete metadata snapshot before any playback
+// stream is opened. In subtitle mode, every discovered episode is explicitly
+// pending so an interrupted run never publishes a misleading processed prefix.
+func newIndexCatalog(seriesTitle, seriesURL, subsLocale string, seasons []Season, seasonEpisodes map[string][]SeasonEpisode, prior map[string]indexEpisode, fetchSubs bool) (indexFile, []indexEpisodeWork) {
+	catalog := indexFile{
+		Series:    seriesTitle,
+		SeriesURL: seriesURL,
+		SubsLang:  subsLocale,
+		Seasons:   make([]indexSeason, 0, len(seasons)),
+	}
+	work := make([]indexEpisodeWork, 0)
+	for _, season := range seasons {
+		episodes := seasonEpisodes[season.ID]
+		catalog.Seasons = append(catalog.Seasons, indexSeason{Season: season.SeasonNumber, Episodes: make([]indexEpisode, 0, len(episodes))})
+		seasonIndex := len(catalog.Seasons) - 1
+		for _, ep := range episodes {
+			status := indexStatusIndexed
+			if fetchSubs {
+				status = indexStatusPending
+			}
+			entry := indexEpisode{
+				Episode:        ep.EpisodeNumber,
+				Title:          ep.Title,
+				Description:    ep.Description,
+				ID:             ep.ID,
+				URL:            "https://www.crunchyroll.com/watch/" + ep.ID,
+				AirDate:        ep.AvailabilityStarts,
+				AudioLangs:     collectAudioLangs(ep),
+				Status:         status,
+				SubtitleLocale: subsLocale,
+			}
+			// Preserve only a locally checksum-verified, exact-locale raw ASS
+			// checkpoint. Missing/failed/stale entries stay pending and will be
+			// retried serially after this complete initial snapshot is durable.
+			if fetchSubs && canResumeRawASS(prior[indexEpisodeKey(ep.ID)], subsLocale) {
+				cached := prior[indexEpisodeKey(ep.ID)]
+				entry.Status = indexStatusSubtitleCached
+				entry.SubtitleFile = cached.SubtitleFile
+				entry.SubtitleSHA256 = cached.SubtitleSHA256
+				entry.SubtitleParserVersion = cached.SubtitleParserVersion
+				entry.SubtitleLangs = cached.SubtitleLangs
+			}
+			catalog.Seasons[seasonIndex].Episodes = append(catalog.Seasons[seasonIndex].Episodes, entry)
+			work = append(work, indexEpisodeWork{SeasonIndex: seasonIndex, EpisodeIndex: len(catalog.Seasons[seasonIndex].Episodes) - 1, Episode: ep})
+		}
+	}
+	return catalog, work
+}
+
+func replaceCatalogEpisode(catalog *indexFile, work indexEpisodeWork, entry indexEpisode) {
+	catalog.Seasons[work.SeasonIndex].Episodes[work.EpisodeIndex] = entry
+}
+
+// writeIndex creates a serial, resumable metadata/subtitle index. Legacy .txt
+// files are intentionally ignored: they are derived artifacts without raw-byte
+// hashes and are never upgraded or reported as raw ASS checkpoints.
+func writeIndex(seriesURL, contentID, primaryAudio, primarySubs string, fetchSubs bool) error {
+	return writeIndexWithLoaders(seriesURL, contentID, primaryAudio, primarySubs, fetchSubs, getSeasons, getSeasonEpisodes)
+}
+
+// writeIndexWithLoaders keeps metadata acquisition injectable for deterministic
+// error-path tests while the production path uses the provider-backed loaders.
+func writeIndexWithLoaders(seriesURL, contentID, primaryAudio, primarySubs string, fetchSubs bool, loadSeasons func(string, string, string) []Season, loadEpisodes func(string, string, string) []SeasonEpisode) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			switch value := recovered.(type) {
+			case error:
+				err = fmt.Errorf("index metadata/provider failure: %w", value)
+			default:
+				err = fmt.Errorf("index metadata/provider failure: %v", value)
+			}
+		}
+	}()
+
+	if seriesURL == "" {
+		seriesURL = "https://www.crunchyroll.com/series/" + contentID
+	}
+	if primarySubs == "" {
+		return errors.New("a subtitle locale is required for --index-subs")
+	}
+
+	seasons := loadSeasons(contentID, primaryAudio, primarySubs)
+	if len(seasons) == 0 {
+		return errors.New("no seasons found")
+	}
+	seriesTitle := ""
+	seasonEpisodes := make(map[string][]SeasonEpisode, len(seasons))
+	for _, season := range seasons {
+		episodes := loadEpisodes(season.ID, primaryAudio, primarySubs)
+		seasonEpisodes[season.ID] = episodes
+		if seriesTitle == "" && len(episodes) > 0 && episodes[0].SeriesTitle != "" {
+			seriesTitle = episodes[0].SeriesTitle
+		}
+	}
+	indexPath := indexFilename(seriesTitle, contentID)
+	previous, err := loadIndex(indexPath)
+	if err != nil {
+		return fmt.Errorf("cannot resume %s: %w", indexPath, err)
+	}
+	prior := priorEpisodes(previous)
+	catalog, work := newIndexCatalog(seriesTitle, seriesURL, primarySubs, seasons, seasonEpisodes, prior, fetchSubs)
+	if fetchSubs {
+		priorityIDs := parseIndexPriorityIDs(*indexPriority)
+		var err error
+		work, err = reorderIndexWork(work, priorityIDs)
+		if err != nil {
+			return err
+		}
+	}
+	if err := snapshotIndex(indexPath, &catalog); err != nil {
+		return fmt.Errorf("cannot write initial index %s: %w", indexPath, err)
+	}
+	if !fetchSubs {
+		fmt.Printf("Index written: %s\n", indexPath)
+		return nil
+	}
+
+	subsDir := sanitize(seriesTitle)
+	if subsDir == "Unknown" {
+		subsDir = sanitize(contentID)
+	}
+	subsDir += "_subs"
+	if err := os.MkdirAll(subsDir, 0755); err != nil {
+		return fmt.Errorf("cannot create subtitle directory %s: %w", subsDir, err)
+	}
+
+	for _, item := range work {
+		entry := catalog.Seasons[item.SeasonIndex].Episodes[item.EpisodeIndex]
+		var needsDelay bool
+		entry, needsDelay = checkpointSubtitle(item.Episode, entry, primarySubs, subsDir, prior[indexEpisodeKey(item.Episode.ID)])
+		replaceCatalogEpisode(&catalog, item, entry)
+		// Each terminal state updates the already-complete catalog atomically.
+		if err := snapshotIndex(indexPath, &catalog); err != nil {
+			return fmt.Errorf("cannot checkpoint %s: %w", indexPath, err)
+		}
+		// A checksum-valid raw ASS resume did not touch playback or the
+		// subtitle endpoint. Only actual attempts need the provider pacing delay.
+		if needsDelay {
+			delaySeconds := *indexDelay
+			if delaySeconds < minimumIndexDelaySeconds {
+				delaySeconds = minimumIndexDelaySeconds
+			}
+			time.Sleep(time.Duration(delaySeconds) * time.Second)
+		}
+	}
+
+	fmt.Printf("Index written: %s\n", indexPath)
+	return nil
+}
+
+// checkpointSubtitle returns whether a subtitle playback/fetch attempt was
+// made. Callers use that signal to preserve the provider delay for every
+// attempt (including failures) while allowing verified local checkpoints to
+// advance without sleeping.
+func checkpointSubtitle(ep SeasonEpisode, entry indexEpisode, locale, subsDir string, prior indexEpisode) (indexEpisode, bool) {
+	return checkpointSubtitleWithFetcher(ep, entry, locale, subsDir, prior, fetchSubtitles)
+}
+
+type subtitleFetcher func(string, string) (subtitleFetchResult, error)
+
+func checkpointSubtitleWithFetcher(ep SeasonEpisode, entry indexEpisode, locale, subsDir string, prior indexEpisode, fetch subtitleFetcher) (indexEpisode, bool) {
+	entry.SubtitleLocale = locale
+	if canResumeRawASS(prior, locale) {
+		entry.Status = indexStatusSubtitleCached
+		entry.SubtitleFile = prior.SubtitleFile
+		entry.SubtitleSHA256 = prior.SubtitleSHA256
+		entry.SubtitleParserVersion = rawASSParserVersion
+		entry.SubtitleLangs = prior.SubtitleLangs
+		return entry, false
+	}
+
+	result, err := fetch(ep.ID, locale)
+	entry.SubtitleLangs = result.AvailableLangs
+	if err != nil {
+		var missing *SubtitleLocaleError
+		if errors.As(err, &missing) {
+			entry.Status = indexStatusSubtitleMissing
+		} else {
+			entry.Status = indexStatusSubtitleFailed
+		}
+		entry.Error = redactSensitiveURLs(err.Error())
+		return entry, true
+	}
+
+	relativePath := rawASSPath(subsDir, ep.SeasonNumber, ep.EpisodeNumber, ep.ID)
+	if err := atomicWriteFile(relativePath, result.RawASS, 0644); err != nil {
+		entry.Status = indexStatusSubtitleFailed
+		entry.Error = redactSensitiveURLs(fmt.Sprintf("cache raw ASS: %v", err))
+		return entry, true
+	}
+	sum := sha256.Sum256(result.RawASS)
+	entry.Status = indexStatusSubtitleCached
+	entry.SubtitleFile = relativePath // Link it in the checkpoint immediately.
+	entry.SubtitleSHA256 = hex.EncodeToString(sum[:])
+	entry.SubtitleParserVersion = rawASSParserVersion
+	return entry, true
+}
+
+// parseASS is intentionally a derived-view helper only. The index never uses
+// its output as a cache: raw .ass bytes and their checksum remain canonical.
+// It parses a declared Events format and preserves commas in the Text field.
+var (
+	assOverrideRe = regexp.MustCompile(`\{[^}]*\}`)
+	assNewlineRe  = regexp.MustCompile(`\\[NnHh]`)
+)
+
+func parseASS(data []byte) string {
+	var output strings.Builder
+	inEvents := false
+	var fields []string
+	for _, original := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(original)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inEvents = strings.EqualFold(line, "[Events]")
+			continue
+		}
+		if !inEvents {
+			continue
+		}
+		if strings.HasPrefix(line, "Format:") {
+			fields = splitASSFields(strings.TrimSpace(strings.TrimPrefix(line, "Format:")))
+			continue
+		}
+		if !strings.HasPrefix(line, "Dialogue:") {
+			continue
+		}
+		start, text, ok := parseASSDialogue(strings.TrimSpace(strings.TrimPrefix(line, "Dialogue:")), fields)
+		if !ok {
+			continue
+		}
+		text = strings.TrimSpace(assNewlineRe.ReplaceAllString(assOverrideRe.ReplaceAllString(text, ""), " "))
+		if text != "" {
+			fmt.Fprintf(&output, "[%s] %s\n", formatASSTimestamp(start), text)
+		}
+	}
+	return output.String()
+}
+
+func splitASSFields(format string) []string {
+	parts := strings.Split(format, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
+
+// parseASSDialogue avoids the common SplitN(..., 3) bug, which treats a comma
+// in Text as an early boundary. The ASS grammar specifies Text as the final
+// field; reject a malformed/reordered declaration instead of guessing.
+func parseASSDialogue(payload string, fields []string) (start, text string, ok bool) {
+	if len(fields) == 0 {
+		return "", "", false
+	}
+	startIndex, textIndex := -1, -1
+	for i, field := range fields {
+		switch strings.ToLower(strings.TrimSpace(field)) {
+		case "start":
+			startIndex = i
+		case "text":
+			textIndex = i
+		}
+	}
+	if startIndex < 0 || textIndex != len(fields)-1 {
+		return "", "", false
+	}
+	parts := strings.SplitN(payload, ",", len(fields))
+	if len(parts) != len(fields) {
+		return "", "", false
+	}
+	return strings.TrimSpace(parts[startIndex]), parts[textIndex], true
+}
+
+func formatASSTimestamp(value string) string {
+	value = strings.TrimSpace(value)
+	if dot := strings.IndexByte(value, '.'); dot >= 0 {
+		value = value[:dot]
+	}
+	parts := strings.Split(value, ":")
+	if len(parts) != 3 {
+		return "00:00:00"
+	}
+	hour, errHour := strconv.Atoi(parts[0])
+	minute, errMinute := strconv.Atoi(parts[1])
+	second, errSecond := strconv.Atoi(parts[2])
+	if errHour != nil || errMinute != nil || errSecond != nil || hour < 0 || minute < 0 || second < 0 {
+		return "00:00:00"
+	}
+	return fmt.Sprintf("%02d:%02d:%02d", hour, minute, second)
+}

--- a/index_run.go
+++ b/index_run.go
@@ -10,23 +10,41 @@ import (
 const indexRunSummarySchema = "crunchyroll-downloader.index-run/v1"
 
 type indexRunSummary struct {
-	Schema              string            `json:"schema"`
-	StartedAt           string            `json:"started_at"`
-	FinishedAt          string            `json:"finished_at"`
-	Outcome             string            `json:"outcome"`
-	Totals              map[string]int    `json:"totals"`
-	NewSuccesses        int               `json:"new_successes"`
-	ProviderCalls       int               `json:"provider_calls"`
-	AuthenticationCalls int               `json:"authentication_calls"`
-	CatalogCalls        int               `json:"catalog_calls"`
-	PlaybackOpenCalls   int               `json:"playback_open_calls"`
-	SubtitleFetchCalls  int               `json:"subtitle_fetch_calls"`
-	StreamReleaseCalls  int               `json:"stream_release_calls"`
-	AttemptedIdentities int               `json:"attempted_identities"`
-	Circuit             indexCircuitState `json:"circuit"`
-	CursorProviderID    string            `json:"cursor_provider_id,omitempty"`
-	NextRetryAt         string            `json:"next_retry_at,omitempty"`
-	Error               string            `json:"error,omitempty"`
+	Schema                    string                `json:"schema"`
+	StartedAt                 string                `json:"started_at"`
+	FinishedAt                string                `json:"finished_at"`
+	Outcome                   string                `json:"outcome"`
+	Totals                    map[string]int        `json:"totals"`
+	NewSuccesses              int                   `json:"new_successes"`
+	ProviderCalls             int                   `json:"provider_calls"`
+	AuthenticationCalls       int                   `json:"authentication_calls"`
+	CatalogCalls              int                   `json:"catalog_calls"`
+	PlaybackOpenCalls         int                   `json:"playback_open_calls"`
+	SubtitleFetchCalls        int                   `json:"subtitle_fetch_calls"`
+	StreamReleaseCalls        int                   `json:"stream_release_calls"`
+	AttemptedIdentities       int                   `json:"attempted_identities"`
+	ScheduledTerminalRechecks int                   `json:"scheduled_terminal_rechecks"`
+	CueQuality                indexCueQualityTotals `json:"cue_quality"`
+	Circuit                   indexCircuitState     `json:"circuit"`
+	CursorProviderID          string                `json:"cursor_provider_id,omitempty"`
+	NextRetryAt               string                `json:"next_retry_at,omitempty"`
+	Error                     string                `json:"error,omitempty"`
+}
+
+// indexCueQualityTotals is a snapshot-level rollup of local assessments of
+// checksum-verified raw ASS caches. It never represents provider calls.
+type indexCueQualityTotals struct {
+	Version              string  `json:"version"`
+	CachedIdentities     int     `json:"cached_identities"`
+	DegradedIdentities   int     `json:"degraded_identities"`
+	TotalCues            int     `json:"total_cues"`
+	UsableCues           int     `json:"usable_cues"`
+	MalformedCues        int     `json:"malformed_cues"`
+	EmptyCues            int     `json:"empty_cues"`
+	SkippedCues          int     `json:"skipped_cues"`
+	MaxMalformedCueRatio float64 `json:"max_malformed_cue_ratio"`
+	MaxEmptyCueRatio     float64 `json:"max_empty_cue_ratio"`
+	MaxSkippedCueRatio   float64 `json:"max_skipped_cue_ratio"`
 }
 
 type indexRunOptions struct {
@@ -42,10 +60,20 @@ type indexRunOptions struct {
 
 func emptyIndexRunSummary(startedAt time.Time) indexRunSummary {
 	return indexRunSummary{
-		Schema:    indexRunSummarySchema,
-		StartedAt: startedAt.UTC().Format(time.RFC3339Nano),
-		Totals:    map[string]int{},
-		Circuit:   indexCircuitState{State: "closed"},
+		Schema:     indexRunSummarySchema,
+		StartedAt:  startedAt.UTC().Format(time.RFC3339Nano),
+		Totals:     map[string]int{},
+		CueQuality: emptyIndexCueQualityTotals(),
+		Circuit:    indexCircuitState{State: "closed"},
+	}
+}
+
+func emptyIndexCueQualityTotals() indexCueQualityTotals {
+	return indexCueQualityTotals{
+		Version:              assCueQualityVersion,
+		MaxMalformedCueRatio: maxMalformedASSCueRatio,
+		MaxEmptyCueRatio:     maxEmptyASSCueRatio,
+		MaxSkippedCueRatio:   maxSkippedASSCueRatio,
 	}
 }
 
@@ -73,6 +101,56 @@ func countIndexStatuses(catalog *indexFile) map[string]int {
 		}
 	}
 	return totals
+}
+
+func countIndexCueQuality(catalog *indexFile) indexCueQualityTotals {
+	totals := emptyIndexCueQualityTotals()
+	for _, season := range catalog.Seasons {
+		for _, episode := range season.Episodes {
+			if episode.Status != indexStatusSubtitleCached {
+				continue
+			}
+			totals.CachedIdentities++
+			quality := episode.SubtitleCueQuality
+			if quality == nil {
+				// A valid cache without derived telemetry is conservatively
+				// surfaced as degraded rather than implicitly reported healthy.
+				totals.DegradedIdentities++
+				continue
+			}
+			totals.TotalCues += quality.TotalCues
+			totals.UsableCues += quality.UsableCues
+			totals.MalformedCues += quality.MalformedCues
+			totals.EmptyCues += quality.EmptyCues
+			totals.SkippedCues += quality.SkippedCues
+			if quality.Outcome == "degraded" {
+				totals.DegradedIdentities++
+			}
+		}
+	}
+	return totals
+}
+
+func countScheduledTerminalRechecks(catalog *indexFile) int {
+	if catalog.CatalogSnapshot == "" {
+		return 0
+	}
+	count := 0
+	for _, season := range catalog.Seasons {
+		for _, episode := range season.Episodes {
+			if episode.Status == indexStatusPending && episode.SubtitleRecheckReason != "" && episode.SubtitleRecheckSnapshot != catalog.CatalogSnapshot {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func circuitOutcome(circuit indexCircuitState) string {
+	if circuit.RestrictionEvidence == providerRestrictionRateLimited {
+		return "provider_rate_limited"
+	}
+	return providerRestrictionUnknown
 }
 
 func retryAfterTime(value string, now time.Time) time.Time {
@@ -108,9 +186,11 @@ func processIndexWorkBounded(catalog *indexFile, work []indexEpisodeWork, prior 
 		options.Sleep = time.Sleep
 	}
 	summary = emptyIndexRunSummary(options.StartedAt)
+	summary.ScheduledTerminalRechecks = countScheduledTerminalRechecks(catalog)
 	defer func() {
 		summary.FinishedAt = now().UTC().Format(time.RFC3339Nano)
 		summary.Totals = countIndexStatuses(catalog)
+		summary.CueQuality = countIndexCueQuality(catalog)
 		summary.Circuit = catalog.Checkpoint.Circuit
 		summary.CursorProviderID = catalog.Checkpoint.CursorProviderID
 		if options.ProviderMetrics != nil {
@@ -129,24 +209,33 @@ func processIndexWorkBounded(catalog *indexFile, work []indexEpisodeWork, prior 
 			summary.Outcome = "failed"
 			summary.Error = redactSensitiveURLs(err.Error())
 		} else if summary.Circuit.State == "open" {
-			summary.Outcome = "throttled"
+			summary.Outcome = circuitOutcome(summary.Circuit)
+		} else if summary.Totals[indexStatusRetryableFailed]+summary.Totals[indexStatusPermanentFailed]+summary.Totals[indexStatusUnknownProviderPlaybackRestriction]+summary.Totals[indexStatusProviderRateLimited] > 0 {
+			summary.Outcome = "partial"
+		} else if summary.CueQuality.DegradedIdentities > 0 {
+			summary.Outcome = "degraded"
 		} else if summary.AttemptedIdentities == 0 {
 			summary.Outcome = "unchanged"
-		} else if summary.Totals[indexStatusRetryableFailed]+summary.Totals[indexStatusPermanentFailed]+summary.Totals[indexStatusThrottled] > 0 {
-			summary.Outcome = "partial"
 		} else {
 			summary.Outcome = "succeeded"
 		}
 	}()
 
-	if catalog.Checkpoint.Circuit.State == "open" && catalog.Checkpoint.Circuit.NextEligibleAttemptAt != "" {
-		next, parseErr := time.Parse(time.RFC3339Nano, catalog.Checkpoint.Circuit.NextEligibleAttemptAt)
-		if parseErr == nil && next.After(now()) {
-			summary.NextRetryAt = next.UTC().Format(time.RFC3339Nano)
-			return summary, nil
+	if catalog.Checkpoint.Circuit.State == "open" {
+		if catalog.Checkpoint.Circuit.NextEligibleAttemptAt != "" {
+			next, parseErr := time.Parse(time.RFC3339Nano, catalog.Checkpoint.Circuit.NextEligibleAttemptAt)
+			if parseErr == nil && next.After(now()) {
+				summary.NextRetryAt = next.UTC().Format(time.RFC3339Nano)
+				return summary, nil
+			}
 		}
+		// An expired or malformed open cooldown starts a fresh circuit streak.
+		// A normally closed circuit, however, retains its consecutive 4294
+		// count across bounded runs so the window cannot evade the global gate.
+		catalog.Checkpoint.Circuit = indexCircuitState{State: "closed"}
+	} else {
+		catalog.Checkpoint.Circuit.State = "closed"
 	}
-	catalog.Checkpoint.Circuit = indexCircuitState{State: "closed"}
 
 	for _, item := range work {
 		entry := catalog.Seasons[item.SeasonIndex].Episodes[item.EpisodeIndex]
@@ -180,10 +269,12 @@ func processIndexWorkBounded(catalog *indexFile, work []indexEpisodeWork, prior 
 
 		if entry.ProviderApplicationCode == playback4294Code {
 			catalog.Checkpoint.Circuit.Consecutive4294++
+			catalog.Checkpoint.Circuit.RestrictionEvidence = entry.ProviderRestriction
 		} else {
 			catalog.Checkpoint.Circuit.Consecutive4294 = 0
+			catalog.Checkpoint.Circuit.RestrictionEvidence = ""
 		}
-		if entry.Status == indexStatusThrottled || entry.Status == indexStatusRetryableFailed {
+		if entry.Status == indexStatusUnknownProviderPlaybackRestriction || entry.Status == indexStatusProviderRateLimited || entry.Status == indexStatusRetryableFailed {
 			next := retryAfterTime(entry.RetryAfter, now())
 			if next.IsZero() {
 				next = now().Add(options.CircuitCooldown)
@@ -202,6 +293,12 @@ func processIndexWorkBounded(catalog *indexFile, work []indexEpisodeWork, prior 
 			catalog.Checkpoint.Circuit.OpenedAt = now().UTC().Format(time.RFC3339Nano)
 			catalog.Checkpoint.Circuit.NextEligibleAttemptAt = next.UTC().Format(time.RFC3339Nano)
 			entry.SubtitleNextEligibleAt = catalog.Checkpoint.Circuit.NextEligibleAttemptAt
+			if catalog.Checkpoint.Circuit.RestrictionEvidence == "" {
+				catalog.Checkpoint.Circuit.RestrictionEvidence = providerRestrictionUnknown
+			}
+		}
+		if entry.SubtitleRecheckReason != "" && catalog.CatalogSnapshot != "" {
+			entry.SubtitleRecheckSnapshot = catalog.CatalogSnapshot
 		}
 		replaceCatalogEpisode(catalog, item, entry)
 		if snapshotErr := snapshot(catalog); snapshotErr != nil {

--- a/index_run.go
+++ b/index_run.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const indexRunSummarySchema = "crunchyroll-downloader.index-run/v1"
+
+type indexRunSummary struct {
+	Schema              string            `json:"schema"`
+	StartedAt           string            `json:"started_at"`
+	FinishedAt          string            `json:"finished_at"`
+	Outcome             string            `json:"outcome"`
+	Totals              map[string]int    `json:"totals"`
+	NewSuccesses        int               `json:"new_successes"`
+	ProviderCalls       int               `json:"provider_calls"`
+	AuthenticationCalls int               `json:"authentication_calls"`
+	CatalogCalls        int               `json:"catalog_calls"`
+	PlaybackOpenCalls   int               `json:"playback_open_calls"`
+	SubtitleFetchCalls  int               `json:"subtitle_fetch_calls"`
+	StreamReleaseCalls  int               `json:"stream_release_calls"`
+	AttemptedIdentities int               `json:"attempted_identities"`
+	Circuit             indexCircuitState `json:"circuit"`
+	CursorProviderID    string            `json:"cursor_provider_id,omitempty"`
+	NextRetryAt         string            `json:"next_retry_at,omitempty"`
+	Error               string            `json:"error,omitempty"`
+}
+
+type indexRunOptions struct {
+	Window           int
+	Circuit4294Limit int
+	CircuitCooldown  time.Duration
+	Delay            time.Duration
+	Sleep            playbackSleeper
+	Now              func() time.Time
+	StartedAt        time.Time
+	ProviderMetrics  func() providerCallMetrics
+}
+
+func emptyIndexRunSummary(startedAt time.Time) indexRunSummary {
+	return indexRunSummary{
+		Schema:    indexRunSummarySchema,
+		StartedAt: startedAt.UTC().Format(time.RFC3339Nano),
+		Totals:    map[string]int{},
+		Circuit:   indexCircuitState{State: "closed"},
+	}
+}
+
+func writeIndexRunSummary(path string, summary indexRunSummary) error {
+	data, err := jsonMarshalIndentNewline(summary)
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(path, data, 0600)
+}
+
+func jsonMarshalIndentNewline(value any) ([]byte, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func countIndexStatuses(catalog *indexFile) map[string]int {
+	totals := map[string]int{}
+	for _, season := range catalog.Seasons {
+		for _, episode := range season.Episodes {
+			totals[episode.Status]++
+		}
+	}
+	return totals
+}
+
+func retryAfterTime(value string, now time.Time) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+		return now.Add(time.Duration(seconds) * time.Second)
+	}
+	if parsed, err := http.ParseTime(value); err == nil {
+		return parsed.UTC()
+	}
+	return time.Time{}
+}
+
+func isEligibleEpisode(entry indexEpisode, now time.Time) bool {
+	if entry.Status == indexStatusSubtitleCached || entry.Status == indexStatusSubtitleMissing || entry.Status == indexStatusPermanentFailed {
+		return false
+	}
+	if entry.SubtitleNextEligibleAt == "" {
+		return true
+	}
+	next, err := time.Parse(time.RFC3339Nano, entry.SubtitleNextEligibleAt)
+	return err != nil || !next.After(now)
+}
+
+func processIndexWorkBounded(catalog *indexFile, work []indexEpisodeWork, prior map[string]indexEpisode, locale, subsDir string, fetch subtitleFetcher, snapshot indexSnapshotter, options indexRunOptions) (summary indexRunSummary, err error) {
+	now := options.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	if options.Sleep == nil {
+		options.Sleep = time.Sleep
+	}
+	summary = emptyIndexRunSummary(options.StartedAt)
+	defer func() {
+		summary.FinishedAt = now().UTC().Format(time.RFC3339Nano)
+		summary.Totals = countIndexStatuses(catalog)
+		summary.Circuit = catalog.Checkpoint.Circuit
+		summary.CursorProviderID = catalog.Checkpoint.CursorProviderID
+		if options.ProviderMetrics != nil {
+			metrics := options.ProviderMetrics()
+			summary.AuthenticationCalls = metrics.Authentication
+			summary.CatalogCalls = metrics.Catalog
+			summary.PlaybackOpenCalls = metrics.PlaybackOpen
+			summary.SubtitleFetchCalls = metrics.SubtitleFetch
+			summary.StreamReleaseCalls = metrics.StreamRelease
+			summary.ProviderCalls = metrics.total()
+		}
+		if summary.NextRetryAt == "" {
+			summary.NextRetryAt = catalog.Checkpoint.Circuit.NextEligibleAttemptAt
+		}
+		if err != nil {
+			summary.Outcome = "failed"
+			summary.Error = redactSensitiveURLs(err.Error())
+		} else if summary.Circuit.State == "open" {
+			summary.Outcome = "throttled"
+		} else if summary.AttemptedIdentities == 0 {
+			summary.Outcome = "unchanged"
+		} else if summary.Totals[indexStatusRetryableFailed]+summary.Totals[indexStatusPermanentFailed]+summary.Totals[indexStatusThrottled] > 0 {
+			summary.Outcome = "partial"
+		} else {
+			summary.Outcome = "succeeded"
+		}
+	}()
+
+	if catalog.Checkpoint.Circuit.State == "open" && catalog.Checkpoint.Circuit.NextEligibleAttemptAt != "" {
+		next, parseErr := time.Parse(time.RFC3339Nano, catalog.Checkpoint.Circuit.NextEligibleAttemptAt)
+		if parseErr == nil && next.After(now()) {
+			summary.NextRetryAt = next.UTC().Format(time.RFC3339Nano)
+			return summary, nil
+		}
+	}
+	catalog.Checkpoint.Circuit = indexCircuitState{State: "closed"}
+
+	for _, item := range work {
+		entry := catalog.Seasons[item.SeasonIndex].Episodes[item.EpisodeIndex]
+		if !isEligibleEpisode(entry, now()) {
+			continue
+		}
+		if summary.AttemptedIdentities >= options.Window {
+			break
+		}
+		beforeCached := entry.Status == indexStatusSubtitleCached
+		entry, attempted := checkpointSubtitleWithFetcher(item.Episode, entry, locale, subsDir, prior[indexEpisodeKey(item.Episode.ID)], fetch)
+		if !attempted {
+			continue
+		}
+		summary.AttemptedIdentities++
+		playbackCalls := entry.SubtitleAttemptCount - prior[indexEpisodeKey(item.Episode.ID)].SubtitleAttemptCount
+		if playbackCalls < 1 {
+			playbackCalls = 1
+		}
+		subtitleCalls := entry.SubtitleFetchAttemptCount - prior[indexEpisodeKey(item.Episode.ID)].SubtitleFetchAttemptCount
+		releaseCalls := entry.StreamReleaseAttemptCount - prior[indexEpisodeKey(item.Episode.ID)].StreamReleaseAttemptCount
+		summary.PlaybackOpenCalls += playbackCalls
+		summary.SubtitleFetchCalls += subtitleCalls
+		summary.StreamReleaseCalls += releaseCalls
+		summary.ProviderCalls += playbackCalls + subtitleCalls + releaseCalls
+		if entry.Status == indexStatusSubtitleCached && !beforeCached {
+			summary.NewSuccesses++
+		}
+		catalog.Checkpoint.CursorProviderID = item.Episode.ID
+		catalog.Checkpoint.UpdatedAt = now().UTC().Format(time.RFC3339Nano)
+
+		if entry.ProviderApplicationCode == playback4294Code {
+			catalog.Checkpoint.Circuit.Consecutive4294++
+		} else {
+			catalog.Checkpoint.Circuit.Consecutive4294 = 0
+		}
+		if entry.Status == indexStatusThrottled || entry.Status == indexStatusRetryableFailed {
+			next := retryAfterTime(entry.RetryAfter, now())
+			if next.IsZero() {
+				next = now().Add(options.CircuitCooldown)
+			}
+			entry.SubtitleNextEligibleAt = next.UTC().Format(time.RFC3339Nano)
+			if summary.NextRetryAt == "" || entry.SubtitleNextEligibleAt < summary.NextRetryAt {
+				summary.NextRetryAt = entry.SubtitleNextEligibleAt
+			}
+		}
+		if catalog.Checkpoint.Circuit.Consecutive4294 >= options.Circuit4294Limit {
+			next := retryAfterTime(entry.RetryAfter, now())
+			if next.IsZero() {
+				next = now().Add(options.CircuitCooldown)
+			}
+			catalog.Checkpoint.Circuit.State = "open"
+			catalog.Checkpoint.Circuit.OpenedAt = now().UTC().Format(time.RFC3339Nano)
+			catalog.Checkpoint.Circuit.NextEligibleAttemptAt = next.UTC().Format(time.RFC3339Nano)
+			entry.SubtitleNextEligibleAt = catalog.Checkpoint.Circuit.NextEligibleAttemptAt
+		}
+		replaceCatalogEpisode(catalog, item, entry)
+		if snapshotErr := snapshot(catalog); snapshotErr != nil {
+			return summary, snapshotErr
+		}
+		if catalog.Checkpoint.Circuit.State == "open" {
+			break
+		}
+		options.Sleep(options.Delay)
+	}
+	return summary, nil
+}

--- a/index_run_test.go
+++ b/index_run_test.go
@@ -57,11 +57,61 @@ func TestProcessIndexWorkBoundedOpensGlobalCircuitAndStopsPlayback(t *testing.T)
 		t.Fatalf("unexpected bounded telemetry: snapshots=%d summary=%#v", snapshots, summary)
 	}
 	wantRetry := now.Add(2 * time.Minute).Format(time.RFC3339Nano)
-	if summary.Outcome != "throttled" || summary.Circuit.State != "open" || summary.NextRetryAt != wantRetry {
+	if summary.Outcome != "provider_rate_limited" || summary.Circuit.State != "open" || summary.NextRetryAt != wantRetry {
 		t.Fatalf("unexpected circuit summary: %#v", summary)
 	}
 	if got := catalog.Seasons[0].Episodes[2].Status; got != indexStatusPending {
 		t.Fatalf("breaker swept a third identity: status=%q", got)
+	}
+}
+
+func TestProcessIndexWorkBoundedPreservesClosed4294StreakAcrossRuns(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	catalog, work := boundedCatalog("first", "second")
+	options := boundedOptions(now)
+	options.Window = 1
+	fetch := func(id, _ string) (subtitleFetchResult, error) {
+		return subtitleFetchResult{PlaybackAttempts: 1}, &PlaybackAPIError{EpisodeID: id, Code: playback4294Code, HTTPStatus: 403}
+	}
+
+	first, err := processIndexWorkBounded(&catalog, work, nil, "en-US", t.TempDir(), fetch, func(*indexFile) error { return nil }, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.AttemptedIdentities != 1 || catalog.Checkpoint.Circuit.State != "closed" || catalog.Checkpoint.Circuit.Consecutive4294 != 1 {
+		t.Fatalf("first bounded run lost circuit streak: summary=%#v circuit=%#v", first, catalog.Checkpoint.Circuit)
+	}
+
+	prior := priorEpisodes(catalog)
+	second, err := processIndexWorkBounded(&catalog, work, prior, "en-US", t.TempDir(), fetch, func(*indexFile) error { return nil }, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.AttemptedIdentities != 1 || second.Circuit.State != "open" || second.Circuit.Consecutive4294 != 2 {
+		t.Fatalf("second bounded run did not open global circuit: summary=%#v", second)
+	}
+}
+
+func TestProcessIndexWorkBoundedClearsExpiredOpenCircuit(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	catalog, work := boundedCatalog("terminal")
+	entry := catalog.Seasons[0].Episodes[0]
+	entry.Status = indexStatusSubtitleMissing
+	replaceCatalogEpisode(&catalog, work[0], entry)
+	catalog.Checkpoint.Circuit = indexCircuitState{
+		State: "open", Consecutive4294: 2,
+		NextEligibleAttemptAt: now.Add(-time.Minute).Format(time.RFC3339Nano),
+		RestrictionEvidence:   providerRestrictionUnknown,
+	}
+	summary, err := processIndexWorkBounded(&catalog, work, priorEpisodes(catalog), "en-US", t.TempDir(), func(string, string) (subtitleFetchResult, error) {
+		t.Fatal("expired circuit with terminal work must not fetch")
+		return subtitleFetchResult{}, nil
+	}, func(*indexFile) error { return nil }, boundedOptions(now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Circuit.State != "closed" || summary.Circuit.Consecutive4294 != 0 || summary.Circuit.RestrictionEvidence != "" {
+		t.Fatalf("expired circuit was not cleared: %#v", summary.Circuit)
 	}
 }
 
@@ -78,8 +128,25 @@ func TestProcessIndexWorkBoundedHonorsPersistedCooldownWithoutProviderCalls(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	if called || summary.AttemptedIdentities != 0 || summary.Outcome != "throttled" || summary.NextRetryAt != next {
+	if called || summary.AttemptedIdentities != 0 || summary.Outcome != providerRestrictionUnknown || summary.NextRetryAt != next {
 		t.Fatalf("persisted cooldown was not honored: called=%v summary=%#v", called, summary)
+	}
+}
+
+func TestProcessIndexWorkBoundedReportsUnknownProviderPlaybackRestrictionWithoutRateEvidence(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	catalog, work := boundedCatalog("first", "second")
+	summary, err := processIndexWorkBounded(&catalog, work, nil, "en-US", t.TempDir(), func(id, _ string) (subtitleFetchResult, error) {
+		return subtitleFetchResult{PlaybackAttempts: 1}, &PlaybackAPIError{EpisodeID: id, Code: playback4294Code, HTTPStatus: 403}
+	}, func(*indexFile) error { return nil }, boundedOptions(now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Outcome != providerRestrictionUnknown || summary.Circuit.RestrictionEvidence != providerRestrictionUnknown {
+		t.Fatalf("unsupported causal inference in summary: %#v", summary)
+	}
+	if got := catalog.Seasons[0].Episodes[0].Status; got != indexStatusUnknownProviderPlaybackRestriction {
+		t.Fatalf("first status=%q", got)
 	}
 }
 
@@ -140,8 +207,9 @@ func TestCheckpointSubtitleClassifiesTypedTerminalOutcomes(t *testing.T) {
 		{name: "missing locale", err: &SubtitleLocaleError{EpisodeID: "episode", Locale: "en-US"}, want: indexStatusSubtitleMissing},
 		{name: "locale mismatch", err: &SubtitleLocaleMismatchError{Requested: "en-US", Actual: "ja-JP"}, want: indexStatusPermanentFailed},
 		{name: "provider 404", err: &HTTPStatusError{URL: "https://cdn.example", StatusCode: 404}, want: indexStatusPermanentFailed},
+		{name: "provider 429", err: &HTTPStatusError{URL: "https://cdn.example", StatusCode: 429}, want: indexStatusProviderRateLimited},
 		{name: "provider 503", err: &HTTPStatusError{URL: "https://cdn.example", StatusCode: 503}, want: indexStatusRetryableFailed},
-		{name: "playback 4294", err: &PlaybackAPIError{EpisodeID: "episode", Code: playback4294Code}, want: indexStatusThrottled},
+		{name: "playback 4294 without direct rate evidence", err: &PlaybackAPIError{EpisodeID: "episode", Code: playback4294Code}, want: indexStatusUnknownProviderPlaybackRestriction},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -156,6 +224,52 @@ func TestCheckpointSubtitleClassifiesTypedTerminalOutcomes(t *testing.T) {
 				t.Fatalf("status=%q attempted=%v want=%q", entry.Status, attempted, test.want)
 			}
 		})
+	}
+}
+
+func TestCheckpointSubtitleClassifiesDirectRateLimitEvidenceSeparately(t *testing.T) {
+	entry, attempted := checkpointSubtitleWithFetcher(
+		SeasonEpisode{ID: "episode", SeasonNumber: 1, EpisodeNumber: 1}, indexEpisode{}, "en-US", t.TempDir(), indexEpisode{},
+		func(string, string) (subtitleFetchResult, error) {
+			return subtitleFetchResult{PlaybackAttempts: 1}, &PlaybackAPIError{EpisodeID: "episode", Code: playback4294Code, HTTPStatus: 403, RetryAfter: "60"}
+		},
+	)
+	if !attempted || entry.Status != indexStatusProviderRateLimited || entry.ProviderRestriction != providerRestrictionRateLimited {
+		t.Fatalf("direct rate evidence=%#v attempted=%v", entry, attempted)
+	}
+}
+
+func TestProcessIndexWorkBoundedReportsDegradedCueQuality(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	catalog, work := boundedCatalog("episode")
+	raw := []byte("[Events]\nFormat: Start, Text\nDialogue: 0:01:02.00,{\\i1}\n")
+	summary, err := processIndexWorkBounded(&catalog, work, nil, "en-US", t.TempDir(), func(_ string, locale string) (subtitleFetchResult, error) {
+		return subtitleFetchResult{AvailableLangs: []string{locale}, RawASS: raw, PlaybackAttempts: 1, SubtitleFetchAttempts: 1}, nil
+	}, func(*indexFile) error { return nil }, boundedOptions(now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Outcome != "degraded" || summary.CueQuality.Version != assCueQualityVersion || summary.CueQuality.CachedIdentities != 1 || summary.CueQuality.DegradedIdentities != 1 || summary.CueQuality.EmptyCues != 1 {
+		t.Fatalf("cue-quality summary=%#v", summary)
+	}
+}
+
+func TestProcessIndexWorkBoundedRecordsSnapshotForAttemptedSparseRecheck(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	catalog, work := boundedCatalog("episode")
+	catalog.CatalogSnapshot = "catalog-snapshot/v1:current"
+	entry := catalog.Seasons[0].Episodes[0]
+	entry.SubtitleRecheckReason = "catalog_snapshot_changed"
+	replaceCatalogEpisode(&catalog, work[0], entry)
+	raw := []byte("[Events]\nFormat: Start, Text\nDialogue: 0:01:02.00,Recovered\n")
+	summary, err := processIndexWorkBounded(&catalog, work, nil, "en-US", t.TempDir(), func(_ string, locale string) (subtitleFetchResult, error) {
+		return subtitleFetchResult{AvailableLangs: []string{locale}, RawASS: raw, PlaybackAttempts: 1}, nil
+	}, func(*indexFile) error { return nil }, boundedOptions(now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.ScheduledTerminalRechecks != 1 || catalog.Seasons[0].Episodes[0].SubtitleRecheckSnapshot != catalog.CatalogSnapshot {
+		t.Fatalf("sparse recheck checkpoint=%#v summary=%#v", catalog.Seasons[0].Episodes[0], summary)
 	}
 }
 

--- a/index_run_test.go
+++ b/index_run_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func boundedCatalog(ids ...string) (indexFile, []indexEpisodeWork) {
+	episodes := make([]SeasonEpisode, 0, len(ids))
+	for position, id := range ids {
+		episodes = append(episodes, SeasonEpisode{
+			ID: id, SeriesTitle: "Series", SeasonNumber: 1,
+			EpisodeNumber:      len(ids) - position,
+			AvailabilityStarts: time.Date(2026, 7, 21-position, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		})
+	}
+	return newIndexCatalog(
+		"Series", "https://example.test/series", "en-US",
+		[]Season{{ID: "season", SeasonNumber: 1}},
+		map[string][]SeasonEpisode{"season": episodes}, nil, true,
+	)
+}
+
+func boundedOptions(now time.Time) indexRunOptions {
+	return indexRunOptions{
+		Window: 5, Circuit4294Limit: 2, CircuitCooldown: 30 * time.Minute,
+		Sleep: func(time.Duration) {}, Now: func() time.Time { return now }, StartedAt: now,
+	}
+}
+
+func TestProcessIndexWorkBoundedOpensGlobalCircuitAndStopsPlayback(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	catalog, work := boundedCatalog("first", "second", "must-not-open")
+	var calls []string
+	var snapshots int
+	fetch := func(id, _ string) (subtitleFetchResult, error) {
+		calls = append(calls, id)
+		return subtitleFetchResult{PlaybackAttempts: 1}, &PlaybackAPIError{
+			EpisodeID: id, Code: playback4294Code, HTTPStatus: 403, RetryAfter: "120",
+		}
+	}
+	summary, err := processIndexWorkBounded(&catalog, work, nil, "en-US", t.TempDir(), fetch, func(*indexFile) error {
+		snapshots++
+		return nil
+	}, boundedOptions(now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 2 || calls[0] != "first" || calls[1] != "second" {
+		t.Fatalf("playback calls = %#v, want exactly first and second", calls)
+	}
+	if snapshots != 2 || summary.AttemptedIdentities != 2 || summary.ProviderCalls != 2 || summary.PlaybackOpenCalls != 2 {
+		t.Fatalf("unexpected bounded telemetry: snapshots=%d summary=%#v", snapshots, summary)
+	}
+	wantRetry := now.Add(2 * time.Minute).Format(time.RFC3339Nano)
+	if summary.Outcome != "throttled" || summary.Circuit.State != "open" || summary.NextRetryAt != wantRetry {
+		t.Fatalf("unexpected circuit summary: %#v", summary)
+	}
+	if got := catalog.Seasons[0].Episodes[2].Status; got != indexStatusPending {
+		t.Fatalf("breaker swept a third identity: status=%q", got)
+	}
+}
+
+func TestProcessIndexWorkBoundedHonorsPersistedCooldownWithoutProviderCalls(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	catalog, work := boundedCatalog("blocked")
+	next := now.Add(20 * time.Minute).Format(time.RFC3339Nano)
+	catalog.Checkpoint.Circuit = indexCircuitState{State: "open", Consecutive4294: 2, NextEligibleAttemptAt: next}
+	called := false
+	summary, err := processIndexWorkBounded(&catalog, work, nil, "en-US", t.TempDir(), func(string, string) (subtitleFetchResult, error) {
+		called = true
+		return subtitleFetchResult{}, errors.New("must not be called")
+	}, func(*indexFile) error { return nil }, boundedOptions(now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if called || summary.AttemptedIdentities != 0 || summary.Outcome != "throttled" || summary.NextRetryAt != next {
+		t.Fatalf("persisted cooldown was not honored: called=%v summary=%#v", called, summary)
+	}
+}
+
+func TestProcessIndexWorkBoundedPreservesCacheAndCountsProviderBoundaries(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	raw := []byte("[Script Info]\n[Events]\nFormat: Start, Text\n")
+	cachedPath := rawASSPath(dir, 1, 2, "cached")
+	if err := atomicWriteFile(cachedPath, raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := sha256File(cachedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prior := map[string]indexEpisode{"cached": {
+		Status: indexStatusSubtitleCached, SubtitleFile: cachedPath, SubtitleLocale: "en-US",
+		SubtitleSHA256: digest, SubtitleParserVersion: rawASSParserVersion,
+	}}
+	seasons := []Season{{ID: "season", SeasonNumber: 1}}
+	episodes := map[string][]SeasonEpisode{"season": {
+		{ID: "cached", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 2},
+		{ID: "fresh", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 1},
+	}}
+	catalog, work := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, episodes, prior, true)
+	var fetched []string
+	options := boundedOptions(now)
+	options.Window = 1
+	summary, err := processIndexWorkBounded(&catalog, work, prior, "en-US", dir, func(id, locale string) (subtitleFetchResult, error) {
+		fetched = append(fetched, id)
+		return subtitleFetchResult{
+			AvailableLangs: []string{locale}, RawASS: raw,
+			PlaybackAttempts: 1, SubtitleFetchAttempts: 1, StreamReleaseAttempts: 1,
+			StreamReleaseOutcome: "released",
+		}, nil
+	}, func(*indexFile) error { return nil }, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fetched) != 1 || fetched[0] != "fresh" {
+		t.Fatalf("verified cache was fetched or fresh work was skipped: %#v", fetched)
+	}
+	if summary.NewSuccesses != 1 || summary.ProviderCalls != 3 || summary.PlaybackOpenCalls != 1 || summary.SubtitleFetchCalls != 1 || summary.StreamReleaseCalls != 1 {
+		t.Fatalf("provider-call telemetry = %#v", summary)
+	}
+	actual, err := os.ReadFile(cachedPath)
+	if err != nil || string(actual) != string(raw) {
+		t.Fatalf("cached bytes changed: err=%v bytes=%q", err, actual)
+	}
+}
+
+func TestCheckpointSubtitleClassifiesTypedTerminalOutcomes(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "missing locale", err: &SubtitleLocaleError{EpisodeID: "episode", Locale: "en-US"}, want: indexStatusSubtitleMissing},
+		{name: "locale mismatch", err: &SubtitleLocaleMismatchError{Requested: "en-US", Actual: "ja-JP"}, want: indexStatusPermanentFailed},
+		{name: "provider 404", err: &HTTPStatusError{URL: "https://cdn.example", StatusCode: 404}, want: indexStatusPermanentFailed},
+		{name: "provider 503", err: &HTTPStatusError{URL: "https://cdn.example", StatusCode: 503}, want: indexStatusRetryableFailed},
+		{name: "playback 4294", err: &PlaybackAPIError{EpisodeID: "episode", Code: playback4294Code}, want: indexStatusThrottled},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entry, attempted := checkpointSubtitleWithFetcher(
+				SeasonEpisode{ID: "episode", SeasonNumber: 1, EpisodeNumber: 1}, indexEpisode{},
+				"en-US", t.TempDir(), indexEpisode{},
+				func(string, string) (subtitleFetchResult, error) {
+					return subtitleFetchResult{PlaybackAttempts: 1}, test.err
+				},
+			)
+			if !attempted || entry.Status != test.want {
+				t.Fatalf("status=%q attempted=%v want=%q", entry.Status, attempted, test.want)
+			}
+		})
+	}
+}
+
+func TestWriteIndexRunSummaryIsPrivateAndMachineReadable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "summary.json")
+	summary := emptyIndexRunSummary(time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC))
+	summary.FinishedAt = "2026-07-21T12:00:01Z"
+	summary.Outcome = "partial"
+	if err := writeIndexRunSummary(path, summary); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("summary mode=%#o want 0600", info.Mode().Perm())
+	}
+	var parsed indexRunSummary
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Schema != indexRunSummarySchema || parsed.Outcome != "partial" {
+		t.Fatalf("unexpected terminal summary: %#v", parsed)
+	}
+}

--- a/index_test.go
+++ b/index_test.go
@@ -93,7 +93,7 @@ func TestCheckpointSubtitleFetchFailureRequiresDelay(t *testing.T) {
 	}
 }
 
-func TestFetchSubtitlesRetries4294AndReleasesSuccessfulPlayback(t *testing.T) {
+func TestFetchSubtitlesSurfacesFirst4294ToGlobalCircuit(t *testing.T) {
 	originalOpen := openIndexPlayback
 	originalSleep := sleepPlaybackRetry
 	originalRetries := *playback4294Retries
@@ -111,19 +111,16 @@ func TestFetchSubtitlesRetries4294AndReleasesSuccessfulPlayback(t *testing.T) {
 	var delays []time.Duration
 	openIndexPlayback = func(id string) Episode {
 		calls++
-		if calls == 1 {
-			panic(&PlaybackAPIError{EpisodeID: id, Code: playback4294Code})
-		}
-		return Episode{Subtitles: map[string]*Subtitle{}}
+		panic(&PlaybackAPIError{EpisodeID: id, Code: playback4294Code})
 	}
 	sleepPlaybackRetry = func(delay time.Duration) { delays = append(delays, delay) }
 
 	_, err := fetchSubtitles("episode", "en-US")
-	var missing *SubtitleLocaleError
-	if !errors.As(err, &missing) {
-		t.Fatalf("fetchSubtitles() error = %v, want SubtitleLocaleError", err)
+	var playbackErr *PlaybackAPIError
+	if !errors.As(err, &playbackErr) || playbackErr.Code != playback4294Code {
+		t.Fatalf("fetchSubtitles() error = %v, want typed 4294", err)
 	}
-	if calls != 2 || len(delays) != 1 || delays[0] != 4*time.Second {
+	if calls != 1 || len(delays) != 0 {
 		t.Fatalf("calls=%d delays=%v", calls, delays)
 	}
 }
@@ -270,6 +267,15 @@ func TestParseIndexPriorityIDsTrimsAndDeduplicates(t *testing.T) {
 	}
 }
 
+func TestIndexPlayback4294RetriesAreOwnedByGlobalCircuit(t *testing.T) {
+	original := *playback4294Retries
+	t.Cleanup(func() { *playback4294Retries = original })
+	*playback4294Retries = 5
+	if got := indexPlayback4294Retries(); got != 0 {
+		t.Fatalf("index playback retries = %d, want 0", got)
+	}
+}
+
 func TestReorderIndexWorkPrioritizesDeclaredOrderAndRetainsAll(t *testing.T) {
 	work := indexWorkForIDs("first", "second", "third", "fourth")
 	got, err := reorderIndexWork(work, parseIndexPriorityIDs(" third, first "))
@@ -317,6 +323,113 @@ func TestReorderIndexWorkEmptyPriorityPreservesOriginal(t *testing.T) {
 	}
 	if gotIDs := indexWorkIDs(got); len(gotIDs) != 2 || gotIDs[0] != "first" || gotIDs[1] != "second" {
 		t.Fatalf("empty priority reordered work: %#v", gotIDs)
+	}
+}
+
+func TestSortIndexWorkNewestFirstUsesStableCanonicalTies(t *testing.T) {
+	work := []indexEpisodeWork{
+		{Episode: SeasonEpisode{ID: "older", SeasonNumber: 99, EpisodeNumber: 999, AvailabilityStarts: "2025-01-01T00:00:00Z"}},
+		{Episode: SeasonEpisode{ID: "variant-z", SeasonNumber: 2, EpisodeNumber: 10, AvailabilityStarts: "2026-01-01T00:00:00Z"}},
+		{Episode: SeasonEpisode{ID: "variant-a", SeasonNumber: 2, EpisodeNumber: 10, AvailabilityStarts: "2026-01-01T00:00:00Z"}},
+		{Episode: SeasonEpisode{ID: "episode-nine", SeasonNumber: 2, EpisodeNumber: 9, AvailabilityStarts: "2026-01-01T00:00:00Z"}},
+		{Episode: SeasonEpisode{ID: "season-one", SeasonNumber: 1, EpisodeNumber: 100, AvailabilityStarts: "2026-01-01T00:00:00Z"}},
+	}
+	got := indexWorkIDs(sortIndexWorkNewestFirst(work))
+	want := []string{"variant-a", "variant-z", "episode-nine", "season-one", "older"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("newest-first IDs = %#v, want %#v", got, want)
+	}
+	if work[0].Episode.ID != "older" {
+		t.Fatalf("sort mutated provider/catalog work: %#v", indexWorkIDs(work))
+	}
+}
+
+func TestProcessIndexWorkSnapshotsEveryIdentityAndContinuesAfterFailure(t *testing.T) {
+	seasons := []Season{{ID: "season", SeasonNumber: 1}}
+	episodes := map[string][]SeasonEpisode{"season": {
+		{ID: "newest", SeasonNumber: 1, EpisodeNumber: 3, AvailabilityStarts: "2026-01-03T00:00:00Z", Title: "Newest", SeriesTitle: "Series"},
+		{ID: "middle", SeasonNumber: 1, EpisodeNumber: 2, AvailabilityStarts: "2026-01-02T00:00:00Z", Title: "Middle", SeriesTitle: "Series"},
+		{ID: "oldest", SeasonNumber: 1, EpisodeNumber: 1, AvailabilityStarts: "2026-01-01T00:00:00Z", Title: "Oldest", SeriesTitle: "Series"},
+	}}
+	catalog, work := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, episodes, nil, true)
+	work = sortIndexWorkNewestFirst(work)
+	var fetched []string
+	fetch := func(id, locale string) (subtitleFetchResult, error) {
+		fetched = append(fetched, id)
+		if id == "newest" {
+			return subtitleFetchResult{}, &PlaybackAPIError{EpisodeID: id, Code: playback4294Code}
+		}
+		return subtitleFetchResult{AvailableLangs: []string{locale}, RawASS: []byte("[Events]\n")}, nil
+	}
+	var snapshots [][]string
+	snapshot := func(file *indexFile) error {
+		statuses := make([]string, 0, 3)
+		for _, episode := range file.Seasons[0].Episodes {
+			statuses = append(statuses, episode.Status)
+		}
+		snapshots = append(snapshots, statuses)
+		return nil
+	}
+	var sleeps []time.Duration
+	err := processIndexWork(&catalog, work, nil, "en-US", t.TempDir(), fetch, snapshot, 7*time.Second, func(delay time.Duration) {
+		sleeps = append(sleeps, delay)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(fetched, ",") != "newest,middle,oldest" {
+		t.Fatalf("failure blocked older work: fetched=%#v", fetched)
+	}
+	if len(snapshots) != 3 || snapshots[0][0] != indexStatusThrottled || snapshots[0][1] != indexStatusPending || snapshots[2][2] != indexStatusSubtitleCached {
+		t.Fatalf("per-record snapshots = %#v", snapshots)
+	}
+	if len(sleeps) != 3 || sleeps[0] != 7*time.Second {
+		t.Fatalf("attempt pacing = %#v", sleeps)
+	}
+	if got := catalog.Seasons[0].Episodes[0].SubtitleAttemptCount; got != 1 {
+		t.Fatalf("failed attempt count = %d, want 1", got)
+	}
+	if catalog.Seasons[0].Episodes[0].SubtitleLastAttemptAt == "" {
+		t.Fatal("failed identity did not persist last-attempt time")
+	}
+}
+
+func TestProcessIndexWorkRestartSkipsVerifiedCacheAndRetriesFailedIdentity(t *testing.T) {
+	dir := t.TempDir()
+	raw := []byte("[Events]\n")
+	cachedPath := rawASSPath(dir, 1, 2, "cached")
+	if err := atomicWriteFile(cachedPath, raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(raw)
+	prior := map[string]indexEpisode{
+		"cached": {Status: indexStatusSubtitleCached, SubtitleFile: cachedPath, SubtitleLocale: "en-US", SubtitleSHA256: hex.EncodeToString(sum[:]), SubtitleParserVersion: rawASSParserVersion},
+		"failed": {Status: indexStatusSubtitleFailed, SubtitleLocale: "en-US", SubtitleAttemptCount: 3, Error: "playback API error: code 4294"},
+	}
+	seasons := []Season{{ID: "season", SeasonNumber: 1}}
+	episodes := map[string][]SeasonEpisode{"season": {
+		{ID: "cached", SeasonNumber: 1, EpisodeNumber: 2, AvailabilityStarts: "2026-01-02T00:00:00Z", SeriesTitle: "Series"},
+		{ID: "failed", SeasonNumber: 1, EpisodeNumber: 1, AvailabilityStarts: "2026-01-01T00:00:00Z", SeriesTitle: "Series"},
+	}}
+	catalog, work := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, episodes, prior, true)
+	var fetched []string
+	err := processIndexWork(&catalog, sortIndexWorkNewestFirst(work), prior, "en-US", dir, func(id, locale string) (subtitleFetchResult, error) {
+		fetched = append(fetched, id)
+		return subtitleFetchResult{AvailableLangs: []string{locale}, RawASS: raw, PlaybackAttempts: 2}, nil
+	}, func(*indexFile) error { return nil }, time.Second, func(time.Duration) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(fetched, ",") != "failed" {
+		t.Fatalf("restart fetched verified cache or skipped failure: %#v", fetched)
+	}
+	for _, episode := range catalog.Seasons[0].Episodes {
+		if episode.Status != indexStatusSubtitleCached {
+			t.Fatalf("restart did not converge to cached: %#v", catalog.Seasons[0].Episodes)
+		}
+		if episode.ID == "failed" && episode.SubtitleAttemptCount != 5 {
+			t.Fatalf("restart attempt count = %d, want 5", episode.SubtitleAttemptCount)
+		}
 	}
 }
 

--- a/index_test.go
+++ b/index_test.go
@@ -212,12 +212,221 @@ func TestInitialCatalogPreservesOnlyVerifiedPriorCheckpoints(t *testing.T) {
 	}
 }
 
+func TestInitialCatalogMigratesLegacy4294InferenceToNeutralRestriction(t *testing.T) {
+	seasons := []Season{{ID: "season", SeasonNumber: 1}}
+	episodes := map[string][]SeasonEpisode{"season": {{ID: "episode", EpisodeNumber: 1, SeriesTitle: "Series"}}}
+	prior := map[string]indexEpisode{
+		"episode": {Status: legacyIndexStatusThrottled, SubtitleLocale: "en-US", SubtitleAttemptCount: 4},
+	}
+	catalog, _ := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, episodes, prior, true)
+	entry := catalog.Seasons[0].Episodes[0]
+	if entry.Status != indexStatusUnknownProviderPlaybackRestriction || entry.SubtitleAttemptCount != 4 {
+		t.Fatalf("legacy provider state was not safely normalized: %#v", entry)
+	}
+}
+
 func TestParseASSPreservesCommasInText(t *testing.T) {
 	raw := []byte("[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\nDialogue: 0,0:01:02.34,0:01:04.00,Default,,0,0,0,,Hello, world, again!\\N{\\i1}Still here\n")
 	got := parseASS(raw)
 	want := "[00:01:02] Hello, world, again! Still here\n"
 	if got != want {
 		t.Fatalf("parseASS() = %q, want %q", got, want)
+	}
+}
+
+func TestAssessASSCueQualityReportsMalformedEmptyAndSkippedCues(t *testing.T) {
+	raw := []byte("[Events]\nFormat: Start, Text\nDialogue: 0:01:02.34,Valid cue\nDialogue: malformed\nDialogue: 0:01:04.00,{\\i1}\nDialogue: invalid-time,Skipped cue\n")
+	transcript, quality := parseASSWithCueQuality(raw)
+	if transcript != "[00:01:02] Valid cue\n" {
+		t.Fatalf("transcript=%q", transcript)
+	}
+	if quality.Version != assCueQualityVersion || quality.TotalCues != 4 || quality.UsableCues != 1 || quality.MalformedCues != 1 || quality.EmptyCues != 1 || quality.SkippedCues != 1 || quality.Outcome != "degraded" {
+		t.Fatalf("cue quality=%#v", quality)
+	}
+	if quality.MaxMalformedCueRatio != maxMalformedASSCueRatio || quality.MaxEmptyCueRatio != maxEmptyASSCueRatio || quality.MaxSkippedCueRatio != maxSkippedASSCueRatio {
+		t.Fatalf("cue-quality thresholds=%#v", quality)
+	}
+}
+
+func TestAssessASSCueQualityAllowsCountsWithinExplicitThresholds(t *testing.T) {
+	var raw strings.Builder
+	raw.WriteString("[Events]\nFormat: Start, Text\n")
+	for i := 0; i < 20; i++ {
+		raw.WriteString("Dialogue: 0:01:02.00,Valid cue\n")
+	}
+	raw.WriteString("Dialogue: malformed\n")
+	quality := assessASSCueQuality([]byte(raw.String()))
+	if quality.MalformedCues != 1 || quality.TotalCues != 21 || quality.Outcome != "healthy" {
+		t.Fatalf("cue quality=%#v", quality)
+	}
+}
+
+func TestCheckpointSubtitleCachesDegradedRawASSWithoutChangingBytes(t *testing.T) {
+	dir := t.TempDir()
+	raw := []byte("[Events]\nFormat: Start, Text\nDialogue: 0:01:02.00,{\\i1}\n")
+	entry, attempted := checkpointSubtitleWithFetcher(
+		SeasonEpisode{ID: "episode", SeasonNumber: 1, EpisodeNumber: 1}, indexEpisode{}, "en-US", dir, indexEpisode{},
+		func(string, string) (subtitleFetchResult, error) {
+			return subtitleFetchResult{AvailableLangs: []string{"en-US"}, RawASS: raw, PlaybackAttempts: 1, SubtitleFetchAttempts: 1}, nil
+		},
+	)
+	if !attempted || entry.Status != indexStatusSubtitleCached || entry.SubtitleCueQuality == nil || entry.SubtitleCueQuality.Outcome != "degraded" {
+		t.Fatalf("checkpoint=%#v attempted=%v", entry, attempted)
+	}
+	stored, err := os.ReadFile(entry.SubtitleFile)
+	if err != nil || string(stored) != string(raw) {
+		t.Fatalf("stored raw ASS err=%v bytes=%q", err, stored)
+	}
+}
+
+func TestCheckpointSubtitleAddsCueTelemetryToVerifiedCacheWithoutRedownload(t *testing.T) {
+	dir := t.TempDir()
+	raw := []byte("[Events]\nFormat: Start, Text\nDialogue: 0:01:02.00,Existing cache\n")
+	path := rawASSPath(dir, 1, 1, "episode")
+	if err := atomicWriteFile(path, raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(raw)
+	prior := indexEpisode{
+		Status: indexStatusSubtitleCached, SubtitleFile: path, SubtitleLocale: "en-US",
+		SubtitleSHA256: hex.EncodeToString(sum[:]), SubtitleParserVersion: rawASSParserVersion,
+	}
+	entry, attempted := checkpointSubtitleWithFetcher(
+		SeasonEpisode{ID: "episode", SeasonNumber: 1, EpisodeNumber: 1}, indexEpisode{}, "en-US", dir, prior,
+		func(string, string) (subtitleFetchResult, error) {
+			t.Fatal("verified cache must not redownload")
+			return subtitleFetchResult{}, nil
+		},
+	)
+	if attempted || entry.SubtitleCueQuality == nil || entry.SubtitleCueQuality.Outcome != "healthy" {
+		t.Fatalf("checkpoint=%#v attempted=%v", entry, attempted)
+	}
+	stored, err := os.ReadFile(path)
+	if err != nil || string(stored) != string(raw) {
+		t.Fatalf("cached raw ASS changed err=%v bytes=%q", err, stored)
+	}
+}
+
+func TestScheduleSparseTerminalRechecksIsSnapshotAwareAndBounded(t *testing.T) {
+	seasons := []Season{{ID: "season", SeasonNumber: 1}}
+	initialEpisodes := map[string][]SeasonEpisode{"season": {
+		{ID: "old-newest", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 3, AvailabilityStarts: "2026-07-03T00:00:00Z"},
+		{ID: "old-middle", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 2, AvailabilityStarts: "2026-07-02T00:00:00Z"},
+		{ID: "old-oldest", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 1, AvailabilityStarts: "2026-07-01T00:00:00Z"},
+	}}
+	previous, _ := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, initialEpisodes, nil, true)
+	prior := priorEpisodes(previous)
+	for id, entry := range prior {
+		entry.Status = indexStatusSubtitleMissing
+		prior[id] = entry
+	}
+
+	currentEpisodes := map[string][]SeasonEpisode{"season": {
+		{ID: "fresh", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 4, AvailabilityStarts: "2026-07-04T00:00:00Z"},
+		initialEpisodes["season"][0], initialEpisodes["season"][1], initialEpisodes["season"][2],
+	}}
+	current, work := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, currentEpisodes, prior, true)
+	work = sortIndexWorkNewestFirst(work)
+	if got := scheduleSparseTerminalRechecks(&current, work, prior, previous.CatalogSnapshot, 2); got != 2 {
+		t.Fatalf("scheduled=%d want=2", got)
+	}
+	byID := priorEpisodes(current)
+	if byID["fresh"].Status != indexStatusPending || byID["old-newest"].Status != indexStatusPending || byID["old-middle"].Status != indexStatusPending || byID["old-oldest"].Status != indexStatusSubtitleMissing {
+		t.Fatalf("sparse scheduling swept or reordered rows: %#v", byID)
+	}
+	if byID["old-newest"].SubtitleRecheckReason != "catalog_snapshot_changed" || byID["old-middle"].SubtitleRecheckReason != "catalog_snapshot_changed" {
+		t.Fatalf("unexpected sparse recheck reasons: %#v", byID)
+	}
+
+	// Once an unchanged snapshot has been recorded for a terminal recheck, it
+	// cannot trigger a repeat playback attempt on the next resumed run.
+	for _, id := range []string{"old-newest", "old-middle"} {
+		entry := byID[id]
+		entry.Status = indexStatusSubtitleMissing
+		entry.SubtitleRecheckSnapshot = current.CatalogSnapshot
+		prior[id] = entry
+	}
+	stable, stableWork := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, currentEpisodes, prior, true)
+	if got := scheduleSparseTerminalRechecks(&stable, sortIndexWorkNewestFirst(stableWork), prior, current.CatalogSnapshot, 2); got != 0 {
+		t.Fatalf("unchanged snapshot rescheduled %d terminal rows", got)
+	}
+}
+
+func TestScheduleSparseTerminalRechecksPrioritizesSourceVersionChange(t *testing.T) {
+	seasons := []Season{{ID: "season", SeasonNumber: 1}}
+	initialEpisodes := map[string][]SeasonEpisode{"season": {{ID: "episode", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 1, Title: "Original", AvailabilityStarts: "2026-07-01T00:00:00Z"}}}
+	previous, _ := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, initialEpisodes, nil, true)
+	prior := priorEpisodes(previous)
+	entry := prior["episode"]
+	entry.Status = indexStatusPermanentFailed
+	prior["episode"] = entry
+
+	updatedEpisodes := map[string][]SeasonEpisode{"season": {{ID: "episode", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 1, Title: "Updated", AvailabilityStarts: "2026-07-01T00:00:00Z"}}}
+	current, work := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, updatedEpisodes, prior, true)
+	if got := scheduleSparseTerminalRechecks(&current, sortIndexWorkNewestFirst(work), prior, previous.CatalogSnapshot, 1); got != 1 {
+		t.Fatalf("scheduled=%d want=1", got)
+	}
+	updated := current.Seasons[0].Episodes[0]
+	if updated.Status != indexStatusPending || updated.SubtitleRecheckReason != "source_version_changed" {
+		t.Fatalf("source-version recheck=%#v", updated)
+	}
+}
+
+func TestScheduleSparseTerminalRechecksKeepsPriorityOrderAndRetainsSourceTruth(t *testing.T) {
+	seasons := []Season{{ID: "season", SeasonNumber: 1}}
+	initialEpisodes := map[string][]SeasonEpisode{"season": {
+		{ID: "snapshot-only", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 3, Title: "Stable", AvailabilityStarts: "2026-07-03T00:00:00Z"},
+		{ID: "source-first", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 2, Title: "Original A", AvailabilityStarts: "2026-07-02T00:00:00Z"},
+		{ID: "source-later", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 1, Title: "Original B", AvailabilityStarts: "2026-07-01T00:00:00Z"},
+	}}
+	previous, _ := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, initialEpisodes, nil, true)
+	prior := priorEpisodes(previous)
+	for id, entry := range prior {
+		entry.Status = indexStatusSubtitleMissing
+		entry.SubtitleCheckedSourceVersion = entry.SourceVersion
+		prior[id] = entry
+	}
+
+	currentEpisodes := map[string][]SeasonEpisode{"season": {
+		{ID: "fresh", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 4, Title: "Fresh", AvailabilityStarts: "2026-07-04T00:00:00Z"},
+		initialEpisodes["season"][0],
+		{ID: "source-first", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 2, Title: "Updated A", AvailabilityStarts: "2026-07-02T00:00:00Z"},
+		{ID: "source-later", SeriesTitle: "Series", SeasonNumber: 1, EpisodeNumber: 1, Title: "Updated B", AvailabilityStarts: "2026-07-01T00:00:00Z"},
+	}}
+	current, work := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, currentEpisodes, prior, true)
+	ordered, err := reorderIndexWork(sortIndexWorkNewestFirst(work), []string{"snapshot-only"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := scheduleSparseTerminalRechecks(&current, ordered, prior, previous.CatalogSnapshot, 1); got != 1 {
+		t.Fatalf("scheduled=%d want=1", got)
+	}
+	byID := priorEpisodes(current)
+	if entry := byID["snapshot-only"]; entry.Status != indexStatusPending || entry.SubtitleRecheckReason != "catalog_snapshot_changed" {
+		t.Fatalf("priority snapshot recheck did not win quota: %#v", entry)
+	}
+	if byID["source-first"].Status != indexStatusSubtitleMissing || byID["source-later"].Status != indexStatusSubtitleMissing {
+		t.Fatalf("source changes exceeded the quota: %#v", byID)
+	}
+	if byID["source-first"].SubtitleCheckedSourceVersion == byID["source-first"].SourceVersion {
+		t.Fatalf("deferred source change was erased: %#v", byID["source-first"])
+	}
+
+	resumedPrior := priorEpisodes(current)
+	resumed, resumedWork := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, currentEpisodes, resumedPrior, true)
+	resumedOrdered, err := reorderIndexWork(sortIndexWorkNewestFirst(resumedWork), []string{"snapshot-only"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := scheduleSparseTerminalRechecks(&resumed, resumedOrdered, resumedPrior, current.CatalogSnapshot, 1); got != 1 {
+		t.Fatalf("resumed source change scheduled=%d want=1", got)
+	}
+	resumedByID := priorEpisodes(resumed)
+	if entry := resumedByID["source-first"]; entry.Status != indexStatusPending || entry.SubtitleRecheckReason != "source_version_changed" {
+		t.Fatalf("deferred source change was not recovered on resume: %#v", entry)
+	}
+	if resumedByID["source-later"].Status != indexStatusSubtitleMissing || resumedByID["source-later"].SubtitleCheckedSourceVersion == resumedByID["source-later"].SourceVersion {
+		t.Fatalf("later source change was not retained beyond resumed quota: %#v", resumedByID["source-later"])
 	}
 }
 
@@ -380,7 +589,7 @@ func TestProcessIndexWorkSnapshotsEveryIdentityAndContinuesAfterFailure(t *testi
 	if strings.Join(fetched, ",") != "newest,middle,oldest" {
 		t.Fatalf("failure blocked older work: fetched=%#v", fetched)
 	}
-	if len(snapshots) != 3 || snapshots[0][0] != indexStatusThrottled || snapshots[0][1] != indexStatusPending || snapshots[2][2] != indexStatusSubtitleCached {
+	if len(snapshots) != 3 || snapshots[0][0] != indexStatusUnknownProviderPlaybackRestriction || snapshots[0][1] != indexStatusPending || snapshots[2][2] != indexStatusSubtitleCached {
 		t.Fatalf("per-record snapshots = %#v", snapshots)
 	}
 	if len(sleeps) != 3 || sleeps[0] != 7*time.Second {

--- a/index_test.go
+++ b/index_test.go
@@ -1,0 +1,362 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCheckpointSubtitleResumesOnlyMatchingRawASS(t *testing.T) {
+	dir := t.TempDir()
+	raw := []byte("[Script Info]\r\nTitle: untouched\r\n[Events]\r\n")
+	path := rawASSPath(dir, 1, 1, "episode")
+	if err := atomicWriteFile(path, raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(raw)
+	prior := indexEpisode{
+		Status:                indexStatusSubtitleCached,
+		SubtitleFile:          path,
+		SubtitleLocale:        "en-US",
+		SubtitleSHA256:        hex.EncodeToString(sum[:]),
+		SubtitleParserVersion: rawASSParserVersion,
+		SubtitleLangs:         []string{"en-US"},
+	}
+	got, needsDelay := checkpointSubtitle(SeasonEpisode{ID: "episode", SeasonNumber: 1, EpisodeNumber: 1}, indexEpisode{}, "en-US", dir, prior)
+	if needsDelay {
+		t.Fatal("verified cached checkpoint must not require a provider delay")
+	}
+	if got.Status != indexStatusSubtitleCached || got.SubtitleFile != path || got.SubtitleSHA256 != prior.SubtitleSHA256 {
+		t.Fatalf("unexpected verified resume checkpoint: %#v", got)
+	}
+	actual, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(actual) != string(raw) {
+		t.Fatalf("raw ASS changed: got %q want %q", actual, raw)
+	}
+	if err := os.WriteFile(path, []byte("changed"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if canResumeRawASS(prior, "en-US") {
+		t.Fatal("checksum mismatch must not be resumed")
+	}
+}
+
+func TestCheckpointSubtitleFetchSuccessRequiresDelay(t *testing.T) {
+	dir := t.TempDir()
+	raw := []byte("[Script Info]\n[Events]\n")
+	fetch := func(episodeID, locale string) (subtitleFetchResult, error) {
+		if episodeID != "episode" || locale != "en-US" {
+			t.Fatalf("unexpected fetch request: episode=%q locale=%q", episodeID, locale)
+		}
+		return subtitleFetchResult{AvailableLangs: []string{"en-US"}, RawASS: raw}, nil
+	}
+
+	got, needsDelay := checkpointSubtitleWithFetcher(
+		SeasonEpisode{ID: "episode", SeasonNumber: 1, EpisodeNumber: 1},
+		indexEpisode{}, "en-US", dir, indexEpisode{}, fetch,
+	)
+	if !needsDelay {
+		t.Fatal("successful subtitle fetch must require a provider delay")
+	}
+	if got.Status != indexStatusSubtitleCached || got.SubtitleFile != rawASSPath(dir, 1, 1, "episode") {
+		t.Fatalf("unexpected successful fetch checkpoint: %#v", got)
+	}
+}
+
+func TestCheckpointSubtitleFetchFailureRequiresDelay(t *testing.T) {
+	dir := t.TempDir()
+	fetch := func(episodeID, locale string) (subtitleFetchResult, error) {
+		if episodeID != "episode" || locale != "en-US" {
+			t.Fatalf("unexpected fetch request: episode=%q locale=%q", episodeID, locale)
+		}
+		return subtitleFetchResult{AvailableLangs: []string{"en-US"}}, errors.New("provider unavailable")
+	}
+
+	got, needsDelay := checkpointSubtitleWithFetcher(
+		SeasonEpisode{ID: "episode", SeasonNumber: 1, EpisodeNumber: 1},
+		indexEpisode{}, "en-US", dir, indexEpisode{}, fetch,
+	)
+	if !needsDelay {
+		t.Fatal("failed subtitle fetch must require a provider delay")
+	}
+	if got.Status != indexStatusSubtitleFailed || got.Error != "provider unavailable" {
+		t.Fatalf("unexpected failed fetch checkpoint: %#v", got)
+	}
+}
+
+func TestFetchSubtitlesRetries4294AndReleasesSuccessfulPlayback(t *testing.T) {
+	originalOpen := openIndexPlayback
+	originalSleep := sleepPlaybackRetry
+	originalRetries := *playback4294Retries
+	originalBackoff := *playback4294Backoff
+	defer func() {
+		openIndexPlayback = originalOpen
+		sleepPlaybackRetry = originalSleep
+		*playback4294Retries = originalRetries
+		*playback4294Backoff = originalBackoff
+	}()
+
+	*playback4294Retries = 2
+	*playback4294Backoff = 4 * time.Second
+	calls := 0
+	var delays []time.Duration
+	openIndexPlayback = func(id string) Episode {
+		calls++
+		if calls == 1 {
+			panic(&PlaybackAPIError{EpisodeID: id, Code: playback4294Code})
+		}
+		return Episode{Subtitles: map[string]*Subtitle{}}
+	}
+	sleepPlaybackRetry = func(delay time.Duration) { delays = append(delays, delay) }
+
+	_, err := fetchSubtitles("episode", "en-US")
+	var missing *SubtitleLocaleError
+	if !errors.As(err, &missing) {
+		t.Fatalf("fetchSubtitles() error = %v, want SubtitleLocaleError", err)
+	}
+	if calls != 2 || len(delays) != 1 || delays[0] != 4*time.Second {
+		t.Fatalf("calls=%d delays=%v", calls, delays)
+	}
+}
+
+func TestRawASSPathIncludesEpisodeID(t *testing.T) {
+	first := rawASSPath("subs", 1, 1, "G123ABC")
+	second := rawASSPath("subs", 1, 1, "G456DEF")
+	if first == second {
+		t.Fatalf("duplicate provider variants collide at %q", first)
+	}
+	if !strings.Contains(first, "G123ABC") || !strings.Contains(second, "G456DEF") {
+		t.Fatalf("episode IDs missing from paths: %q, %q", first, second)
+	}
+}
+
+func TestExactSubtitleForLocaleRejectsLanguageMismatch(t *testing.T) {
+	_, err := exactSubtitleForLocale(map[string]*Subtitle{
+		"en-US": {Language: "ja-JP", URL: "https://cdn.example/sub.ass"},
+	}, "en-US")
+	var mismatch *SubtitleLocaleMismatchError
+	if !errors.As(err, &mismatch) || mismatch.Requested != "en-US" || mismatch.Actual != "ja-JP" {
+		t.Fatalf("expected exact locale mismatch, got %v", err)
+	}
+}
+
+func TestCatalogSnapshotRetainsLaterPendingEpisodes(t *testing.T) {
+	seasons := []Season{{ID: "season", SeasonNumber: 1}}
+	episodes := map[string][]SeasonEpisode{"season": {
+		{ID: "first", EpisodeNumber: 1, Title: "First", SeriesTitle: "Series"},
+		{ID: "second", EpisodeNumber: 2, Title: "Second", SeriesTitle: "Series"},
+	}}
+	catalog, work := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, episodes, nil, true)
+	if len(work) != 2 || catalog.Seasons[0].Episodes[1].Status != indexStatusPending {
+		t.Fatalf("catalog did not predeclare complete pending work: %#v", catalog)
+	}
+	first := catalog.Seasons[0].Episodes[0]
+	first.Status = indexStatusSubtitleMissing
+	replaceCatalogEpisode(&catalog, work[0], first)
+	data, err := marshalIndex(catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot indexFile
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.Seasons[0].Episodes; len(got) != 2 || got[0].Status != indexStatusSubtitleMissing || got[1].ID != "second" || got[1].Status != indexStatusPending {
+		t.Fatalf("terminal update published a partial/misleading snapshot: %#v", snapshot)
+	}
+}
+
+func TestInitialCatalogPreservesOnlyVerifiedPriorCheckpoints(t *testing.T) {
+	dir := t.TempDir()
+	validPath := rawASSPath(dir, 1, 2, "second")
+	raw := []byte("[Script Info]\n[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n")
+	if err := atomicWriteFile(validPath, raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(raw)
+	seasons := []Season{{ID: "season", SeasonNumber: 1}}
+	episodes := map[string][]SeasonEpisode{"season": {
+		{ID: "first", EpisodeNumber: 1, Title: "First", SeriesTitle: "Series"},
+		{ID: "second", EpisodeNumber: 2, Title: "Second", SeriesTitle: "Series"},
+	}}
+	prior := map[string]indexEpisode{
+		"first": {
+			Status:                indexStatusSubtitleCached,
+			SubtitleFile:          validPath,
+			SubtitleLocale:        "en-US",
+			SubtitleSHA256:        "not-the-file-checksum",
+			SubtitleParserVersion: rawASSParserVersion,
+		},
+		"second": {
+			Status:                indexStatusSubtitleCached,
+			SubtitleFile:          validPath,
+			SubtitleLocale:        "en-US",
+			SubtitleSHA256:        hex.EncodeToString(sum[:]),
+			SubtitleParserVersion: rawASSParserVersion,
+			SubtitleLangs:         []string{"en-US"},
+		},
+	}
+	catalog, _ := newIndexCatalog("Series", "https://example.test/series", "en-US", seasons, episodes, prior, true)
+	got := catalog.Seasons[0].Episodes
+	if got[0].Status != indexStatusPending || got[0].SubtitleFile != "" {
+		t.Fatalf("invalid checksum was carried into initial snapshot: %#v", got[0])
+	}
+	if got[1].Status != indexStatusSubtitleCached || got[1].SubtitleFile != validPath || got[1].SubtitleSHA256 != hex.EncodeToString(sum[:]) {
+		t.Fatalf("valid later checkpoint was not retained: %#v", got[1])
+	}
+}
+
+func TestParseASSPreservesCommasInText(t *testing.T) {
+	raw := []byte("[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\nDialogue: 0,0:01:02.34,0:01:04.00,Default,,0,0,0,,Hello, world, again!\\N{\\i1}Still here\n")
+	got := parseASS(raw)
+	want := "[00:01:02] Hello, world, again! Still here\n"
+	if got != want {
+		t.Fatalf("parseASS() = %q, want %q", got, want)
+	}
+}
+
+func TestAtomicWriteFileLeavesNoTemporaryFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "checkpoint.json")
+	if err := atomicWriteFile(path, []byte("complete"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), ".tmp-") {
+			t.Fatalf("temporary file was not cleaned up: %s", entry.Name())
+		}
+	}
+}
+
+func indexWorkForIDs(ids ...string) []indexEpisodeWork {
+	work := make([]indexEpisodeWork, 0, len(ids))
+	for _, id := range ids {
+		work = append(work, indexEpisodeWork{Episode: SeasonEpisode{ID: id}})
+	}
+	return work
+}
+
+func indexWorkIDs(work []indexEpisodeWork) []string {
+	ids := make([]string, 0, len(work))
+	for _, item := range work {
+		ids = append(ids, item.Episode.ID)
+	}
+	return ids
+}
+
+func TestParseIndexPriorityIDsTrimsAndDeduplicates(t *testing.T) {
+	got := parseIndexPriorityIDs(" second, first, second, , first ")
+	want := []string{"second", "first"}
+	if len(got) != len(want) {
+		t.Fatalf("parseIndexPriorityIDs() = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("parseIndexPriorityIDs() = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestReorderIndexWorkPrioritizesDeclaredOrderAndRetainsAll(t *testing.T) {
+	work := indexWorkForIDs("first", "second", "third", "fourth")
+	got, err := reorderIndexWork(work, parseIndexPriorityIDs(" third, first "))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"third", "first", "second", "fourth"}
+	if gotIDs := indexWorkIDs(got); len(gotIDs) != len(want) {
+		t.Fatalf("reorderIndexWork() IDs = %#v, want %#v", gotIDs, want)
+	} else {
+		for i := range want {
+			if gotIDs[i] != want[i] {
+				t.Fatalf("reorderIndexWork() IDs = %#v, want %#v", gotIDs, want)
+			}
+		}
+	}
+	if gotIDs := indexWorkIDs(work); gotIDs[0] != "first" {
+		t.Fatalf("reorderIndexWork() mutated original work: %#v", gotIDs)
+	}
+}
+
+func TestReorderIndexWorkRejectsUnknownIDsDeterministically(t *testing.T) {
+	work := indexWorkForIDs("first", "second")
+	_, err := reorderIndexWork(work, parseIndexPriorityIDs("missing, second, absent, missing"))
+	var priorityErr *IndexPriorityIDsError
+	if !errors.As(err, &priorityErr) {
+		t.Fatalf("expected IndexPriorityIDsError, got %v", err)
+	}
+	want := []string{"missing", "absent"}
+	if len(priorityErr.Unknown) != len(want) {
+		t.Fatalf("unknown IDs = %#v, want %#v", priorityErr.Unknown, want)
+	}
+	for i := range want {
+		if priorityErr.Unknown[i] != want[i] {
+			t.Fatalf("unknown IDs = %#v, want %#v", priorityErr.Unknown, want)
+		}
+	}
+}
+
+func TestReorderIndexWorkEmptyPriorityPreservesOriginal(t *testing.T) {
+	work := indexWorkForIDs("first", "second")
+	got, err := reorderIndexWork(work, parseIndexPriorityIDs(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotIDs := indexWorkIDs(got); len(gotIDs) != 2 || gotIDs[0] != "first" || gotIDs[1] != "second" {
+		t.Fatalf("empty priority reordered work: %#v", gotIDs)
+	}
+}
+
+func TestWriteIndexWithLoadersReturnsNoSeasonsError(t *testing.T) {
+	episodesCalled := false
+	err := writeIndexWithLoaders(
+		"https://example.test/series/series-id", "series-id", "ja-JP", "en-US", false,
+		func(string, string, string) []Season { return nil },
+		func(string, string, string) []SeasonEpisode {
+			episodesCalled = true
+			return nil
+		},
+	)
+	if err == nil || err.Error() != "no seasons found" {
+		t.Fatalf("writeIndexWithLoaders() error = %v, want no seasons found", err)
+	}
+	if episodesCalled {
+		t.Fatal("episode metadata loader called after no seasons")
+	}
+}
+
+func TestWriteIndexWithLoadersConvertsProviderPanicToError(t *testing.T) {
+	err := writeIndexWithLoaders(
+		"https://example.test/series/series-id", "series-id", "ja-JP", "en-US", false,
+		func(string, string, string) []Season { panic("provider unavailable") },
+		func(string, string, string) []SeasonEpisode { return nil },
+	)
+	if err == nil || !strings.Contains(err.Error(), "index metadata/provider failure: provider unavailable") {
+		t.Fatalf("writeIndexWithLoaders() error = %v, want converted provider failure", err)
+	}
+}
+
+func TestRunReturnsAuthenticationSetupErrorWithoutExiting(t *testing.T) {
+	oldPath := *etpRtFile
+	defer func() { *etpRtFile = oldPath }()
+	*etpRtFile = ""
+	t.Setenv("CRUNCHYROLL_ETP_RT", "")
+
+	err := run("https://www.crunchyroll.com/series/series-id", "")
+	if err == nil || !strings.Contains(err.Error(), "Authentication setup failed") {
+		t.Fatalf("run() error = %v, want authentication setup failure", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,9 @@ const (
 	defaultPlayback4294Backoff = 8 * time.Second
 	maxPlayback4294Retries     = 5
 	maxPlayback4294Backoff     = time.Minute
+	defaultIndexWindow         = 25
+	defaultIndexCircuitLimit   = 3
+	defaultIndexCooldown       = 30 * time.Minute
 )
 
 var (
@@ -30,8 +33,12 @@ var (
 	debug                 = flag.Bool("debug-manifest", false, "Log raw episode playback JSON and manifest XML")
 	index                 = flag.Bool("index", false, "Build a metadata catalog of all episodes in a series (no download). Requires a /series/ URL")
 	indexSubs             = flag.Bool("index-subs", false, "Like --index, but also download subtitle transcripts for every episode. Resumable")
-	indexDelay            = flag.Int("index-delay", 3, "Seconds to wait between subtitle fetches (avoids Crunchyroll rate limiting)")
+	indexDelay            = flag.Int("index-delay", 3, "Seconds to wait between subtitle acquisition attempts")
 	indexPriority         = flag.String("index-priority-ids", "", "Episode provider IDs to process first in --index-subs mode, comma-separated")
+	indexWindow           = flag.Int("index-window", defaultIndexWindow, "Maximum provider identities attempted in one resumable index run (1-100)")
+	indexCircuitLimit     = flag.Int("index-circuit-4294-limit", defaultIndexCircuitLimit, "Consecutive provider 4294 responses before the global playback circuit opens")
+	indexCircuitCooldown  = flag.Duration("index-circuit-cooldown", defaultIndexCooldown, "Global cooldown after the playback circuit opens")
+	indexSummaryPath      = flag.String("index-run-summary", "", "Machine-readable terminal run summary path (default: <index>.run-summary.json)")
 	playback4294Retries   = flag.Int("playback-4294-retries", defaultPlayback4294Retries, "Additional retries for playback provider error 4294")
 	playback4294Backoff   = flag.Duration("playback-4294-backoff", defaultPlayback4294Backoff, "Initial backoff for playback provider error 4294")
 	getProcessEpisodeInfo = getEpisodeInfo
@@ -126,6 +133,19 @@ func validatePlaybackRetryConfig(retries int, backoff time.Duration) error {
 	}
 	if backoff <= 0 || backoff > maxPlayback4294Backoff {
 		return fmt.Errorf("--playback-4294-backoff must be greater than 0 and at most %s", maxPlayback4294Backoff)
+	}
+	return nil
+}
+
+func validateIndexRunConfig(window, circuitLimit int, cooldown time.Duration) error {
+	if window < 1 || window > 100 {
+		return fmt.Errorf("--index-window must be between 1 and 100")
+	}
+	if circuitLimit < 1 || circuitLimit > 10 {
+		return fmt.Errorf("--index-circuit-4294-limit must be between 1 and 10")
+	}
+	if cooldown < time.Minute || cooldown > 24*time.Hour {
+		return fmt.Errorf("--index-circuit-cooldown must be between 1m and 24h")
 	}
 	return nil
 }
@@ -238,6 +258,12 @@ func run(url, urlsFile string) error {
 	}
 	if err := validatePlaybackRetryConfig(*playback4294Retries, *playback4294Backoff); err != nil {
 		return err
+	}
+	if (*index || *indexSubs) && *indexSubs {
+		if err := validateIndexRunConfig(*indexWindow, *indexCircuitLimit, *indexCircuitCooldown); err != nil {
+			return err
+		}
+		resetProviderCallMetrics()
 	}
 
 	etpRT, err := loadETPRT(*etpRtFile)

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ var (
 	videoQuality          = flag.String("video-quality", "1080p", "Video quality")
 	audioQuality          = flag.String("audio-quality", "192k", "Audio quality")
 	seasonNumber          = flag.Int("season", 0, "Season number. Not used if an episode link is entered")
-	etpRtFile             = flag.String("etp-rt-file", "", "Path to a 0600 regular file containing the etp_rt cookie (or set CRUNCHYROLL_ETP_RT)")
+	etpRtFile             = flag.String("etp-rt-file", "", "Path to a 0600 regular file containing the etp_rt cookie")
 	debug                 = flag.Bool("debug-manifest", false, "Log raw episode playback JSON and manifest XML")
 	index                 = flag.Bool("index", false, "Build a metadata catalog of all episodes in a series (no download). Requires a /series/ URL")
 	indexSubs             = flag.Bool("index-subs", false, "Like --index, but also download subtitle transcripts for every episode. Resumable")
@@ -118,13 +118,10 @@ func validateOpenedCredentialFile(path string, entryInfo, openedInfo os.FileInfo
 }
 
 func loadETPRT(filePath string) (string, error) {
-	if filePath != "" {
-		return readETPRTFile(filepath.Clean(filePath))
+	if filePath == "" {
+		return "", fmt.Errorf("provide --etp-rt-file with a 0600 regular file")
 	}
-	if secret := strings.TrimSpace(os.Getenv("CRUNCHYROLL_ETP_RT")); secret != "" {
-		return secret, nil
-	}
-	return "", fmt.Errorf("provide --etp-rt-file with a 0600 regular file or set CRUNCHYROLL_ETP_RT")
+	return readETPRTFile(filepath.Clean(filePath))
 }
 
 func validatePlaybackRetryConfig(retries int, backoff time.Duration) error {

--- a/main.go
+++ b/main.go
@@ -2,22 +2,133 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
+	"time"
+)
+
+const (
+	defaultPlayback4294Retries = 2
+	defaultPlayback4294Backoff = 8 * time.Second
+	maxPlayback4294Retries     = 5
+	maxPlayback4294Backoff     = time.Minute
 )
 
 var (
-	token         = ""
-	audioLang     = flag.String("audio-lang", "ja-JP", "Audio language(s), comma-separated for multiple (e.g. \"ja-JP,en-US\"). First is the default track")
-	subtitlesLang = flag.String("subs-lang", "en-US", "Subtitle language(s), comma-separated for multiple (e.g. \"en-US,es-419\"). First is the default track")
-	videoQuality  = flag.String("video-quality", "1080p", "Video quality")
-	audioQuality  = flag.String("audio-quality", "192k", "Audio quality")
-	seasonNumber  = flag.Int("season", 0, "Season number. Not used if an episode link is entered")
-	etpRt         = flag.String("etp-rt", "", "The \"etp_rt\" cookie value of your account")
-	debug         = flag.Bool("debug-manifest", false, "Log raw episode playback JSON and manifest XML")
+	token                 = ""
+	audioLang             = flag.String("audio-lang", "ja-JP", "Audio language(s), comma-separated for multiple (e.g. \"ja-JP,en-US\"). First is the default track")
+	subtitlesLang         = flag.String("subs-lang", "en-US", "Subtitle language(s), comma-separated for multiple (e.g. \"en-US,es-419\"). First is the default track")
+	videoQuality          = flag.String("video-quality", "1080p", "Video quality")
+	audioQuality          = flag.String("audio-quality", "192k", "Audio quality")
+	seasonNumber          = flag.Int("season", 0, "Season number. Not used if an episode link is entered")
+	etpRtFile             = flag.String("etp-rt-file", "", "Path to a 0600 regular file containing the etp_rt cookie (or set CRUNCHYROLL_ETP_RT)")
+	debug                 = flag.Bool("debug-manifest", false, "Log raw episode playback JSON and manifest XML")
+	index                 = flag.Bool("index", false, "Build a metadata catalog of all episodes in a series (no download). Requires a /series/ URL")
+	indexSubs             = flag.Bool("index-subs", false, "Like --index, but also download subtitle transcripts for every episode. Resumable")
+	indexDelay            = flag.Int("index-delay", 3, "Seconds to wait between subtitle fetches (avoids Crunchyroll rate limiting)")
+	indexPriority         = flag.String("index-priority-ids", "", "Episode provider IDs to process first in --index-subs mode, comma-separated")
+	playback4294Retries   = flag.Int("playback-4294-retries", defaultPlayback4294Retries, "Additional retries for playback provider error 4294")
+	playback4294Backoff   = flag.Duration("playback-4294-backoff", defaultPlayback4294Backoff, "Initial backoff for playback provider error 4294")
+	getProcessEpisodeInfo = getEpisodeInfo
 )
+
+const maxETPRTBytes int64 = 16 << 10
+
+// CredentialFileError makes unsafe credential-file rejections actionable
+// without exposing the cookie itself.
+type CredentialFileError struct {
+	Path    string
+	Problem string
+}
+
+func (e *CredentialFileError) Error() string {
+	return fmt.Sprintf("unsafe etp_rt credential file %s: %s", e.Path, e.Problem)
+}
+
+func readETPRTFile(path string) (string, error) {
+	entryInfo, err := os.Lstat(path)
+	if err != nil {
+		return "", fmt.Errorf("stat etp_rt credential file: %w", err)
+	}
+	if err := validateCredentialFileInfo(path, entryInfo); err != nil {
+		return "", err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open etp_rt credential file: %w", err)
+	}
+	defer file.Close()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat opened etp_rt credential file: %w", err)
+	}
+	if err := validateOpenedCredentialFile(path, entryInfo, openedInfo); err != nil {
+		return "", err
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxETPRTBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("read etp_rt credential file: %w", err)
+	}
+	if int64(len(data)) > maxETPRTBytes {
+		return "", &CredentialFileError{Path: path, Problem: "size is outside the permitted range"}
+	}
+	secret := strings.TrimSpace(string(data))
+	if secret == "" {
+		return "", &CredentialFileError{Path: path, Problem: "is empty"}
+	}
+	return secret, nil
+}
+
+func validateCredentialFileInfo(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return &CredentialFileError{Path: path, Problem: "must not be a symlink"}
+	}
+	if !info.Mode().IsRegular() {
+		return &CredentialFileError{Path: path, Problem: "must be a regular file"}
+	}
+	if info.Mode().Perm() != 0600 {
+		return &CredentialFileError{Path: path, Problem: "permissions must be 0600"}
+	}
+	if info.Size() <= 0 || info.Size() > maxETPRTBytes {
+		return &CredentialFileError{Path: path, Problem: "size is outside the permitted range"}
+	}
+	return nil
+}
+
+func validateOpenedCredentialFile(path string, entryInfo, openedInfo os.FileInfo) error {
+	if err := validateCredentialFileInfo(path, openedInfo); err != nil {
+		return err
+	}
+	if !os.SameFile(entryInfo, openedInfo) {
+		return &CredentialFileError{Path: path, Problem: "changed after validation"}
+	}
+	return nil
+}
+
+func loadETPRT(filePath string) (string, error) {
+	if filePath != "" {
+		return readETPRTFile(filepath.Clean(filePath))
+	}
+	if secret := strings.TrimSpace(os.Getenv("CRUNCHYROLL_ETP_RT")); secret != "" {
+		return secret, nil
+	}
+	return "", fmt.Errorf("provide --etp-rt-file with a 0600 regular file or set CRUNCHYROLL_ETP_RT")
+}
+
+func validatePlaybackRetryConfig(retries int, backoff time.Duration) error {
+	if retries < 0 || retries > maxPlayback4294Retries {
+		return fmt.Errorf("--playback-4294-retries must be between 0 and %d", maxPlayback4294Retries)
+	}
+	if backoff <= 0 || backoff > maxPlayback4294Backoff {
+		return fmt.Errorf("--playback-4294-backoff must be greater than 0 and at most %s", maxPlayback4294Backoff)
+	}
+	return nil
+}
 
 // parseLangs splits a comma-separated locale list, trimming spaces and dropping
 // empties.
@@ -31,16 +142,29 @@ func parseLangs(s string) []string {
 	return out
 }
 
-func processUrl(url string) {
-	contentType := strings.Split(url, "/")[3]
-	contentId := strings.Split(url, "/")[4]
-	if len(contentId) < 9 && len(contentId) > 14 {
-		fmt.Printf("Invalid URL format: %s\n", url)
-		return
+func processUrl(url string) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			switch value := recovered.(type) {
+			case error:
+				err = fmt.Errorf("process %s: %w", url, value)
+			default:
+				err = fmt.Errorf("process %s: %v", url, value)
+			}
+		}
+	}()
+
+	parts := strings.Split(url, "/")
+	if len(parts) < 5 {
+		return fmt.Errorf("Invalid URL format: %s", url)
+	}
+	contentType := parts[3]
+	contentId := parts[4]
+	if len(contentId) < 9 || len(contentId) > 14 {
+		return fmt.Errorf("Invalid URL format: %s", url)
 	}
 	if contentType != "watch" && contentType != "series" {
-		fmt.Printf("Invalid URL (must be /watch/ or /series/): %s\n", url)
-		return
+		return fmt.Errorf("Invalid URL (must be /watch/ or /series/): %s", url)
 	}
 
 	audioLangs := parseLangs(*audioLang)
@@ -58,11 +182,25 @@ func processUrl(url string) {
 		primarySubs = subsLangs[0]
 	}
 
+	// Index mode: build a metadata catalog (optionally with subtitles) and exit
+	// without downloading any video. Only meaningful for /series/ URLs.
+	if *index || *indexSubs {
+		if contentType != "series" {
+			return errors.New("--index/--index-subs requires a /series/ URL")
+		}
+		return writeIndex(url, contentId, primaryAudio, primarySubs, *indexSubs)
+	}
+
 	if contentType == "watch" {
-		info := getEpisodeInfo(contentId)
-		downloadEpisode(contentId, info, audioLangs, subsLangs, videoQuality, audioQuality)
+		info := getProcessEpisodeInfo(contentId)
+		if err := downloadEpisode(contentId, info, audioLangs, subsLangs, videoQuality, audioQuality); err != nil {
+			return err
+		}
 	} else {
 		seasons := getSeasons(contentId, primaryAudio, primarySubs)
+		if len(seasons) == 0 {
+			return errors.New("no seasons found")
+		}
 
 		if *seasonNumber != 0 {
 			var seasonId string
@@ -73,45 +211,48 @@ func processUrl(url string) {
 				}
 			}
 			if seasonId == "" {
-				fmt.Printf("This anime has no season %v!\n", *seasonNumber)
-				return
+				return fmt.Errorf("This anime has no season %v!", *seasonNumber)
 			}
 
 			episodes := getSeasonEpisodes(seasonId, primaryAudio, primarySubs)
-			downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, episodes)
+			if err := downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, episodes); err != nil {
+				return err
+			}
 		} else {
-			print("No season number specified, downloading all seasons...\n")
+			fmt.Println("No season number specified, downloading all seasons...")
 
 			for _, season := range seasons {
 				episodes := getSeasonEpisodes(season.ID, primaryAudio, primarySubs)
-				downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, episodes)
+				if err := downloadSeason(videoQuality, audioQuality, audioLangs, subsLangs, episodes); err != nil {
+					return err
+				}
 			}
 		}
 	}
+	return nil
 }
 
-func main() {
-	url := flag.String("url", "", "URL of the episode/season to download")
-	urlsFile := flag.String("file", "", "Path to a text file with one URL per line")
-	flag.Parse()
-
-	if *url == "" && *urlsFile == "" {
-		flag.Usage()
-		os.Exit(1)
+func run(url, urlsFile string) error {
+	if url == "" && urlsFile == "" {
+		return errors.New("provide --url or --file")
+	}
+	if err := validatePlaybackRetryConfig(*playback4294Retries, *playback4294Backoff); err != nil {
+		return err
 	}
 
-	if *etpRt == "" {
-		fmt.Println("You must specify the \"-etp-rt\" option!\n- Open Crunchyroll on your browser and log in.\n- Open developer tools (Ctrl+Shift+I), go to \"Application\", and then \"Cookies\".\n- The value of the \"ept_rt\" cookie is what you need to input into this option.")
-		os.Exit(1)
+	etpRT, err := loadETPRT(*etpRtFile)
+	if err != nil {
+		return fmt.Errorf("Authentication setup failed: %w", err)
+	}
+	setETPRT(etpRT)
+	if err := refreshAccessToken(); err != nil {
+		return fmt.Errorf("Authentication failed: %w", err)
 	}
 
-	token = GetAccessToken(*etpRt)
-
-	if *urlsFile != "" {
-		file, err := os.Open(*urlsFile)
+	if urlsFile != "" {
+		file, err := os.Open(urlsFile)
 		if err != nil {
-			fmt.Printf("Failed to open URLs file: %s\n", err)
-			os.Exit(1)
+			return fmt.Errorf("Failed to open URLs file: %w", err)
 		}
 		defer file.Close()
 
@@ -123,14 +264,41 @@ func main() {
 				urls = append(urls, line)
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("read URLs file: %w", err)
+		}
 
 		fmt.Printf("Found %d URLs to download\n\n", len(urls))
+		failed := false
 		for i, u := range urls {
 			fmt.Printf("=== [%d/%d] %s ===\n", i+1, len(urls), u)
-			processUrl(u)
+			if err := processUrl(u); err != nil {
+				fmt.Printf("! %s\n", err)
+				failed = true
+			}
 			fmt.Println()
 		}
-	} else {
-		processUrl(*url)
+		if failed {
+			return errors.New("one or more URLs failed")
+		}
+		return nil
+	}
+
+	return processUrl(url)
+}
+
+func main() {
+	url := flag.String("url", "", "URL of the episode/season to download")
+	urlsFile := flag.String("file", "", "Path to a text file with one URL per line")
+	flag.Parse()
+
+	if *url == "" && *urlsFile == "" {
+		flag.Usage()
+		fmt.Println("provide --url or --file")
+		os.Exit(1)
+	}
+	if err := run(*url, *urlsFile); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -13,35 +13,37 @@ import (
 )
 
 const (
-	defaultPlayback4294Retries = 2
-	defaultPlayback4294Backoff = 8 * time.Second
-	maxPlayback4294Retries     = 5
-	maxPlayback4294Backoff     = time.Minute
-	defaultIndexWindow         = 25
-	defaultIndexCircuitLimit   = 3
-	defaultIndexCooldown       = 30 * time.Minute
+	defaultPlayback4294Retries        = 2
+	defaultPlayback4294Backoff        = 8 * time.Second
+	maxPlayback4294Retries            = 5
+	maxPlayback4294Backoff            = time.Minute
+	defaultIndexWindow                = 25
+	defaultIndexTerminalRecheckWindow = 3
+	defaultIndexCircuitLimit          = 3
+	defaultIndexCooldown              = 30 * time.Minute
 )
 
 var (
-	token                 = ""
-	audioLang             = flag.String("audio-lang", "ja-JP", "Audio language(s), comma-separated for multiple (e.g. \"ja-JP,en-US\"). First is the default track")
-	subtitlesLang         = flag.String("subs-lang", "en-US", "Subtitle language(s), comma-separated for multiple (e.g. \"en-US,es-419\"). First is the default track")
-	videoQuality          = flag.String("video-quality", "1080p", "Video quality")
-	audioQuality          = flag.String("audio-quality", "192k", "Audio quality")
-	seasonNumber          = flag.Int("season", 0, "Season number. Not used if an episode link is entered")
-	etpRtFile             = flag.String("etp-rt-file", "", "Path to a 0600 regular file containing the etp_rt cookie")
-	debug                 = flag.Bool("debug-manifest", false, "Log raw episode playback JSON and manifest XML")
-	index                 = flag.Bool("index", false, "Build a metadata catalog of all episodes in a series (no download). Requires a /series/ URL")
-	indexSubs             = flag.Bool("index-subs", false, "Like --index, but also download subtitle transcripts for every episode. Resumable")
-	indexDelay            = flag.Int("index-delay", 3, "Seconds to wait between subtitle acquisition attempts")
-	indexPriority         = flag.String("index-priority-ids", "", "Episode provider IDs to process first in --index-subs mode, comma-separated")
-	indexWindow           = flag.Int("index-window", defaultIndexWindow, "Maximum provider identities attempted in one resumable index run (1-100)")
-	indexCircuitLimit     = flag.Int("index-circuit-4294-limit", defaultIndexCircuitLimit, "Consecutive provider 4294 responses before the global playback circuit opens")
-	indexCircuitCooldown  = flag.Duration("index-circuit-cooldown", defaultIndexCooldown, "Global cooldown after the playback circuit opens")
-	indexSummaryPath      = flag.String("index-run-summary", "", "Machine-readable terminal run summary path (default: <index>.run-summary.json)")
-	playback4294Retries   = flag.Int("playback-4294-retries", defaultPlayback4294Retries, "Additional retries for playback provider error 4294")
-	playback4294Backoff   = flag.Duration("playback-4294-backoff", defaultPlayback4294Backoff, "Initial backoff for playback provider error 4294")
-	getProcessEpisodeInfo = getEpisodeInfo
+	token                      = ""
+	audioLang                  = flag.String("audio-lang", "ja-JP", "Audio language(s), comma-separated for multiple (e.g. \"ja-JP,en-US\"). First is the default track")
+	subtitlesLang              = flag.String("subs-lang", "en-US", "Subtitle language(s), comma-separated for multiple (e.g. \"en-US,es-419\"). First is the default track")
+	videoQuality               = flag.String("video-quality", "1080p", "Video quality")
+	audioQuality               = flag.String("audio-quality", "192k", "Audio quality")
+	seasonNumber               = flag.Int("season", 0, "Season number. Not used if an episode link is entered")
+	etpRtFile                  = flag.String("etp-rt-file", "", "Path to a 0600 regular file containing the etp_rt cookie")
+	debug                      = flag.Bool("debug-manifest", false, "Log raw episode playback JSON and manifest XML")
+	index                      = flag.Bool("index", false, "Build a metadata catalog of all episodes in a series (no download). Requires a /series/ URL")
+	indexSubs                  = flag.Bool("index-subs", false, "Like --index, but also download subtitle transcripts for every episode. Resumable")
+	indexDelay                 = flag.Int("index-delay", 3, "Seconds to wait between subtitle acquisition attempts")
+	indexPriority              = flag.String("index-priority-ids", "", "Episode provider IDs to process first in --index-subs mode, comma-separated")
+	indexWindow                = flag.Int("index-window", defaultIndexWindow, "Maximum provider identities attempted in one resumable index run (1-100)")
+	indexTerminalRecheckWindow = flag.Int("index-terminal-recheck-window", defaultIndexTerminalRecheckWindow, "Maximum missing-locale/permanent rows sparsely rechecked after a source version or catalog snapshot change (0-25)")
+	indexCircuitLimit          = flag.Int("index-circuit-4294-limit", defaultIndexCircuitLimit, "Consecutive provider 4294 responses before the global playback circuit opens")
+	indexCircuitCooldown       = flag.Duration("index-circuit-cooldown", defaultIndexCooldown, "Global cooldown after the playback circuit opens")
+	indexSummaryPath           = flag.String("index-run-summary", "", "Machine-readable terminal run summary path (default: <index>.run-summary.json)")
+	playback4294Retries        = flag.Int("playback-4294-retries", defaultPlayback4294Retries, "Additional retries for playback provider error 4294")
+	playback4294Backoff        = flag.Duration("playback-4294-backoff", defaultPlayback4294Backoff, "Initial backoff for playback provider error 4294")
+	getProcessEpisodeInfo      = getEpisodeInfo
 )
 
 const maxETPRTBytes int64 = 16 << 10
@@ -145,6 +147,26 @@ func validateIndexRunConfig(window, circuitLimit int, cooldown time.Duration) er
 		return fmt.Errorf("--index-circuit-cooldown must be between 1m and 24h")
 	}
 	return nil
+}
+
+func validateIndexTerminalRecheckWindow(window int) error {
+	if window < 0 || window > 25 {
+		return fmt.Errorf("--index-terminal-recheck-window must be between 0 and 25")
+	}
+	return nil
+}
+
+func validateBatchIndexSummaryPath(urlCount int, fetchSubs bool, summaryPath string) error {
+	if fetchSubs && urlCount > 1 && strings.TrimSpace(summaryPath) != "" {
+		return errors.New("--index-run-summary cannot be shared by multiple --file URLs; omit it to use per-catalog summary paths")
+	}
+	return nil
+}
+
+func beginBatchIndexCatalogMetrics(fetchSubs bool) {
+	if fetchSubs {
+		resetProviderCallMetrics()
+	}
 }
 
 // parseLangs splits a comma-separated locale list, trimming spaces and dropping
@@ -260,6 +282,9 @@ func run(url, urlsFile string) error {
 		if err := validateIndexRunConfig(*indexWindow, *indexCircuitLimit, *indexCircuitCooldown); err != nil {
 			return err
 		}
+		if err := validateIndexTerminalRecheckWindow(*indexTerminalRecheckWindow); err != nil {
+			return err
+		}
 		resetProviderCallMetrics()
 	}
 
@@ -290,10 +315,14 @@ func run(url, urlsFile string) error {
 		if err := scanner.Err(); err != nil {
 			return fmt.Errorf("read URLs file: %w", err)
 		}
+		if err := validateBatchIndexSummaryPath(len(urls), *indexSubs, *indexSummaryPath); err != nil {
+			return err
+		}
 
 		fmt.Printf("Found %d URLs to download\n\n", len(urls))
 		failed := false
 		for i, u := range urls {
+			beginBatchIndexCatalogMetrics(*indexSubs)
 			fmt.Printf("=== [%d/%d] %s ===\n", i+1, len(urls), u)
 			if err := processUrl(u); err != nil {
 				fmt.Printf("! %s\n", err)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReadETPRTFileRequiresPrivateRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "etp_rt")
+	if err := os.WriteFile(path, []byte(" secret\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readETPRTFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "secret" {
+		t.Fatalf("got %q", got)
+	}
+	if err := os.Chmod(path, 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err = readETPRTFile(path)
+	var unsafe *CredentialFileError
+	if !errors.As(err, &unsafe) {
+		t.Fatalf("expected CredentialFileError, got %v", err)
+	}
+}
+
+func TestValidatePlaybackRetryConfig(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		retries int
+		backoff time.Duration
+	}{
+		{name: "negative retries", retries: -1, backoff: time.Second},
+		{name: "too many retries", retries: maxPlayback4294Retries + 1, backoff: time.Second},
+		{name: "zero backoff", retries: 1, backoff: 0},
+		{name: "excessive backoff", retries: 1, backoff: maxPlayback4294Backoff + time.Second},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validatePlaybackRetryConfig(test.retries, test.backoff); err == nil {
+				t.Fatal("expected invalid playback retry configuration")
+			}
+		})
+	}
+	if err := validatePlaybackRetryConfig(defaultPlayback4294Retries, defaultPlayback4294Backoff); err != nil {
+		t.Fatalf("defaults are invalid: %v", err)
+	}
+}
+
+func TestReadETPRTFileRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("secret"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "etp_rt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readETPRTFile(link)
+	var unsafe *CredentialFileError
+	if !errors.As(err, &unsafe) || unsafe.Problem != "must not be a symlink" {
+		t.Fatalf("expected symlink CredentialFileError, got %v", err)
+	}
+}
+
+func TestValidateOpenedCredentialFileRejectsReplacement(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first")
+	second := filepath.Join(dir, "second")
+	if err := os.WriteFile(first, []byte("first"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte("second"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	entryInfo, err := os.Lstat(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Open(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = validateOpenedCredentialFile(first, entryInfo, openedInfo)
+	var unsafe *CredentialFileError
+	if !errors.As(err, &unsafe) || unsafe.Problem != "changed after validation" {
+		t.Fatalf("expected replacement CredentialFileError, got %v", err)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -30,6 +30,13 @@ func TestReadETPRTFileRequiresPrivateRegularFile(t *testing.T) {
 	}
 }
 
+func TestLoadETPRTRequiresFileEvenWhenLegacyEnvironmentValueExists(t *testing.T) {
+	t.Setenv("CRUNCHYROLL_ETP_RT", "legacy-value-must-not-be-used")
+	if _, err := loadETPRT(""); err == nil || err.Error() != "provide --etp-rt-file with a 0600 regular file" {
+		t.Fatalf("expected file-only credential error, got %v", err)
+	}
+}
+
 func TestValidatePlaybackRetryConfig(t *testing.T) {
 	for _, test := range []struct {
 		name    string

--- a/main_test.go
+++ b/main_test.go
@@ -59,6 +59,36 @@ func TestValidatePlaybackRetryConfig(t *testing.T) {
 	}
 }
 
+func TestValidateIndexTerminalRecheckWindow(t *testing.T) {
+	for _, window := range []int{-1, 26} {
+		if err := validateIndexTerminalRecheckWindow(window); err == nil {
+			t.Fatalf("window %d unexpectedly accepted", window)
+		}
+	}
+	if err := validateIndexTerminalRecheckWindow(defaultIndexTerminalRecheckWindow); err != nil {
+		t.Fatalf("default terminal recheck window rejected: %v", err)
+	}
+}
+
+func TestValidateBatchIndexSummaryPathRejectsSharedExplicitPath(t *testing.T) {
+	if err := validateBatchIndexSummaryPath(2, true, "shared-summary.json"); err == nil {
+		t.Fatal("shared explicit batch summary path was accepted")
+	}
+	for _, test := range []struct {
+		count     int
+		fetchSubs bool
+		path      string
+	}{
+		{count: 2, fetchSubs: true, path: ""},
+		{count: 1, fetchSubs: true, path: "one.json"},
+		{count: 2, fetchSubs: false, path: "unused.json"},
+	} {
+		if err := validateBatchIndexSummaryPath(test.count, test.fetchSubs, test.path); err != nil {
+			t.Fatalf("valid batch summary configuration rejected: %#v err=%v", test, err)
+		}
+	}
+}
+
 func TestReadETPRTFileRejectsSymlink(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target")

--- a/mpd.go
+++ b/mpd.go
@@ -10,6 +10,8 @@ import (
 	"github.com/unki2aut/go-mpd"
 )
 
+var manifestHTTPClient = &http.Client{Timeout: providerHTTPTimeout}
+
 func parseManifest(url string) *mpd.MPD {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -17,7 +19,7 @@ func parseManifest(url string) *mpd.MPD {
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := manifestHTTPClient.Do(req)
 	if err != nil {
 		panic(err)
 	}
@@ -38,11 +40,22 @@ func parseManifest(url string) *mpd.MPD {
 }
 
 func getBaseUrl(set *mpd.AdaptationSet, isVideoSet bool, quality string) (*string, *string) {
-	for _, representation := range set.Representations {
+	var bestVideo *mpd.Representation
+	var bestVideoHeight uint64
+	requestedVideoHeight, requestedVideoHeightErr := strconv.ParseUint(strings.TrimSuffix(quality, "p"), 10, 64)
+
+	for representationIndex := range set.Representations {
+		representation := &set.Representations[representationIndex]
 		if isVideoSet {
-			toInt, _ := strconv.ParseInt(strings.ReplaceAll(quality, "p", ""), 10, 64)
-			if *representation.Height == uint64(toInt) {
+			if representation.Height == nil || len(representation.BaseURL) == 0 || representation.ID == nil {
+				continue
+			}
+			if requestedVideoHeightErr == nil && *representation.Height == requestedVideoHeight {
 				return &representation.BaseURL[0].Value, representation.ID
+			}
+			if *representation.Height > bestVideoHeight {
+				bestVideo = representation
+				bestVideoHeight = *representation.Height
 			}
 		} else {
 			if strings.Contains(*representation.ID, "audio/") {
@@ -63,10 +76,17 @@ func getBaseUrl(set *mpd.AdaptationSet, isVideoSet bool, quality string) (*strin
 			}
 		}
 	}
+	if isVideoSet && bestVideo != nil {
+		fmt.Printf("Video quality %s not found, deferring to %dp (%s)\n", quality, bestVideoHeight, *bestVideo.ID)
+		return &bestVideo.BaseURL[0].Value, bestVideo.ID
+	}
 	if len(set.Representations) == 0 {
 		return nil, nil
 	}
 	firstRep := set.Representations[0]
+	if len(firstRep.BaseURL) == 0 || firstRep.ID == nil {
+		return nil, nil
+	}
 	fmt.Printf("Audio quality %s not found, deferring to %s\n", quality, *firstRep.ID)
 	return &firstRep.BaseURL[0].Value, firstRep.ID
 }

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/unki2aut/go-mpd"
+)
+
+func TestGetBaseURLFallsBackToHighestVideoRepresentation(t *testing.T) {
+	representation := func(id, url string, height uint64) mpd.Representation {
+		return mpd.Representation{
+			ID:      &id,
+			Height:  &height,
+			BaseURL: []*mpd.BaseURL{{Value: url}},
+		}
+	}
+	set := &mpd.AdaptationSet{Representations: []mpd.Representation{
+		representation("video/avc1/480p", "https://example.test/480", 480),
+		representation("video/avc1/720p", "https://example.test/720", 720),
+	}}
+
+	baseURL, representationID := getBaseUrl(set, true, "1080p")
+	if baseURL == nil || *baseURL != "https://example.test/720" {
+		t.Fatalf("expected highest available video URL, got %v", baseURL)
+	}
+	if representationID == nil || *representationID != "video/avc1/720p" {
+		t.Fatalf("expected highest available representation, got %v", representationID)
+	}
+}
+
+func TestGetBaseURLPrefersExactVideoHeight(t *testing.T) {
+	representation := func(id, url string, height uint64) mpd.Representation {
+		return mpd.Representation{
+			ID:      &id,
+			Height:  &height,
+			BaseURL: []*mpd.BaseURL{{Value: url}},
+		}
+	}
+	set := &mpd.AdaptationSet{Representations: []mpd.Representation{
+		representation("video/avc1/480p", "https://example.test/480", 480),
+		representation("video/avc1/720p", "https://example.test/720", 720),
+		representation("video/avc1/1080p", "https://example.test/1080", 1080),
+	}}
+
+	baseURL, representationID := getBaseUrl(set, true, "720p")
+	if baseURL == nil || *baseURL != "https://example.test/720" {
+		t.Fatalf("expected exact video URL, got %v", baseURL)
+	}
+	if representationID == nil || *representationID != "video/avc1/720p" {
+		t.Fatalf("expected exact representation, got %v", representationID)
+	}
+}

--- a/provider_metrics.go
+++ b/provider_metrics.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"sync/atomic"
+)
+
+type providerCallMetrics struct {
+	Authentication int `json:"authentication_calls"`
+	Catalog        int `json:"catalog_calls"`
+	PlaybackOpen   int `json:"playback_open_calls"`
+	SubtitleFetch  int `json:"subtitle_fetch_calls"`
+	StreamRelease  int `json:"stream_release_calls"`
+}
+
+func (m providerCallMetrics) total() int {
+	return m.Authentication + m.Catalog + m.PlaybackOpen + m.SubtitleFetch + m.StreamRelease
+}
+
+var providerCalls struct {
+	authentication atomic.Int64
+	catalog        atomic.Int64
+	playbackOpen   atomic.Int64
+	subtitleFetch  atomic.Int64
+	streamRelease  atomic.Int64
+}
+
+func resetProviderCallMetrics() {
+	providerCalls.authentication.Store(0)
+	providerCalls.catalog.Store(0)
+	providerCalls.playbackOpen.Store(0)
+	providerCalls.subtitleFetch.Store(0)
+	providerCalls.streamRelease.Store(0)
+}
+
+func recordProviderCall(req *http.Request) {
+	path := req.URL.Path
+	switch {
+	case strings.Contains(path, "/auth/v1/token"):
+		providerCalls.authentication.Add(1)
+	case strings.Contains(path, "/content/v2/"):
+		providerCalls.catalog.Add(1)
+	case strings.Contains(path, "/playback/v3/") && strings.HasSuffix(path, "/play"):
+		providerCalls.playbackOpen.Add(1)
+	case req.Method == http.MethodDelete && strings.Contains(path, "/playback/v1/token/"):
+		providerCalls.streamRelease.Add(1)
+	default:
+		providerCalls.subtitleFetch.Add(1)
+	}
+}
+
+func providerCallMetricsSnapshot() providerCallMetrics {
+	return providerCallMetrics{
+		Authentication: int(providerCalls.authentication.Load()),
+		Catalog:        int(providerCalls.catalog.Load()),
+		PlaybackOpen:   int(providerCalls.playbackOpen.Load()),
+		SubtitleFetch:  int(providerCalls.subtitleFetch.Load()),
+		StreamRelease:  int(providerCalls.streamRelease.Load()),
+	}
+}

--- a/provider_metrics_test.go
+++ b/provider_metrics_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestProviderCallMetricsClassifyEveryProviderBoundary(t *testing.T) {
+	resetProviderCallMetrics()
+	requests := []struct {
+		method string
+		url    string
+	}{
+		{http.MethodPost, "https://www.crunchyroll.com/auth/v1/token"},
+		{http.MethodGet, "https://www.crunchyroll.com/content/v2/cms/series/id/seasons"},
+		{http.MethodGet, "https://www.crunchyroll.com/playback/v3/episode/web/firefox/play"},
+		{http.MethodGet, "https://static.crunchyroll.com/subtitles/track.ass?signature=secret"},
+		{http.MethodDelete, "https://www.crunchyroll.com/playback/v1/token/episode/secret"},
+	}
+	for _, item := range requests {
+		req, err := http.NewRequest(item.method, item.url, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		recordProviderCall(req)
+	}
+	metrics := providerCallMetricsSnapshot()
+	if metrics.Authentication != 1 || metrics.Catalog != 1 || metrics.PlaybackOpen != 1 || metrics.SubtitleFetch != 1 || metrics.StreamRelease != 1 {
+		t.Fatalf("unexpected metrics: %+v", metrics)
+	}
+	if metrics.total() != 5 {
+		t.Fatalf("provider total = %d, want 5", metrics.total())
+	}
+}

--- a/provider_metrics_test.go
+++ b/provider_metrics_test.go
@@ -32,3 +32,26 @@ func TestProviderCallMetricsClassifyEveryProviderBoundary(t *testing.T) {
 		t.Fatalf("provider total = %d, want 5", metrics.total())
 	}
 }
+
+func TestBatchIndexCatalogMetricsAreIsolatedPerSummary(t *testing.T) {
+	resetProviderCallMetrics()
+	t.Cleanup(resetProviderCallMetrics)
+	providerCalls.authentication.Add(1) // Shared batch authentication is outside each catalog scope.
+
+	beginBatchIndexCatalogMetrics(true)
+	providerCalls.catalog.Add(3)
+	providerCalls.playbackOpen.Add(2)
+	providerCalls.subtitleFetch.Add(1)
+	first := providerCallMetricsSnapshot()
+	if first.Authentication != 0 || first.Catalog != 3 || first.PlaybackOpen != 2 || first.SubtitleFetch != 1 || first.total() != 6 {
+		t.Fatalf("first catalog metrics=%#v", first)
+	}
+
+	beginBatchIndexCatalogMetrics(true)
+	providerCalls.catalog.Add(2)
+	providerCalls.playbackOpen.Add(1)
+	second := providerCallMetricsSnapshot()
+	if second.Authentication != 0 || second.Catalog != 2 || second.PlaybackOpen != 1 || second.SubtitleFetch != 0 || second.total() != 3 {
+		t.Fatalf("second catalog inherited cumulative metrics: %#v", second)
+	}
+}

--- a/season.go
+++ b/season.go
@@ -19,6 +19,7 @@ type SeasonEpisode struct {
 	SeriesTitle        string        `json:"series_title"`
 	AudioLocale        string        `json:"audio_locale"`
 	Title              string        `json:"title"`
+	Description        string        `json:"description"`
 	AvailabilityStarts string        `json:"availability_starts"`
 }
 

--- a/token.go
+++ b/token.go
@@ -84,6 +84,7 @@ func GetAccessToken(etpRT string) (CrunchyrollTokenResponse, error) {
 	req.AddCookie(&http.Cookie{Name: "device_id", Value: deviceID})
 	req.AddCookie(&http.Cookie{Name: "etp_rt", Value: etpRT})
 
+	recordProviderCall(req)
 	resp, err := tokenHTTPClient.Do(req)
 	if err != nil {
 		return CrunchyrollTokenResponse{}, fmt.Errorf("send token request: %w", err)

--- a/token.go
+++ b/token.go
@@ -7,45 +7,124 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 )
 
-var deviceId = uuid.NewString()
+var deviceID = uuid.NewString()
+
+var tokenEndpoint = "https://www.crunchyroll.com/auth/v1/token"
+var tokenHTTPClient = &http.Client{Timeout: providerHTTPTimeout}
+
+var authState struct {
+	sync.Mutex
+	etpRT     string
+	accountID string
+}
 
 type CrunchyrollTokenResponse struct {
 	AccessToken string `json:"access_token"`
+	AccountID   string `json:"account_id"`
 }
 
-// GetAccessToken fetches an access token from Crunchyroll
-func GetAccessToken(etpRt string) string {
+// TokenError deliberately carries status and a bounded server diagnostic, not
+// the request cookie or response body.
+type TokenError struct {
+	StatusCode int
+	Problem    string
+}
+
+func (e *TokenError) Error() string {
+	if e.StatusCode == 0 {
+		return "token exchange failed: " + e.Problem
+	}
+	return fmt.Sprintf("token exchange failed with HTTP %d: %s", e.StatusCode, e.Problem)
+}
+
+// AccountIdentityMismatchError prevents a refreshed token from quietly moving
+// an in-progress serial run to a different account when the token endpoint
+// provides account_id.
+type AccountIdentityMismatchError struct {
+	Expected string
+	Actual   string
+}
+
+func (e *AccountIdentityMismatchError) Error() string {
+	return "token refresh returned a different account identity"
+}
+
+func setETPRT(secret string) {
+	authState.Lock()
+	defer authState.Unlock()
+	authState.etpRT = secret
+}
+
+func getETPRT() string {
+	authState.Lock()
+	defer authState.Unlock()
+	return authState.etpRT
+}
+
+// GetAccessToken fetches an access token with a supplied cookie. Callers that
+// own a run should use refreshAccessToken so account identity pinning applies.
+func GetAccessToken(etpRT string) (CrunchyrollTokenResponse, error) {
 	body := url.Values{}
-	body.Set("device_id", deviceId)
+	body.Set("device_id", deviceID)
 	body.Set("device_type", "Firefox on Linux")
 	body.Set("grant_type", "etp_rt_cookie")
 
-	req, err := http.NewRequest(http.MethodPost, "https://www.crunchyroll.com/auth/v1/token", strings.NewReader(body.Encode()))
+	req, err := http.NewRequest(http.MethodPost, tokenEndpoint, strings.NewReader(body.Encode()))
 	if err != nil {
-		panic(err)
+		return CrunchyrollTokenResponse{}, fmt.Errorf("build token request: %w", err)
 	}
 	req.Header.Set("Authorization", "Basic bm9haWhkZXZtXzZpeWcwYThsMHE6")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0")
-	req.AddCookie(&http.Cookie{Name: "device_id", Value: deviceId})
-	req.AddCookie(&http.Cookie{Name: "etp_rt", Value: etpRt})
+	req.AddCookie(&http.Cookie{Name: "device_id", Value: deviceID})
+	req.AddCookie(&http.Cookie{Name: "etp_rt", Value: etpRT})
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := tokenHTTPClient.Do(req)
 	if err != nil {
-		panic(err)
+		return CrunchyrollTokenResponse{}, fmt.Errorf("send token request: %w", err)
 	}
 	defer resp.Body.Close()
-
-	// Parse JSON response
-	res, err := io.ReadAll(resp.Body)
-	var result CrunchyrollTokenResponse
-	if err := json.Unmarshal(res, &result); err != nil {
-		panic(fmt.Errorf("failed to get access token: %w", err))
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return CrunchyrollTokenResponse{}, fmt.Errorf("read token response: %w", err)
 	}
+	if resp.StatusCode != http.StatusOK {
+		return CrunchyrollTokenResponse{}, &TokenError{StatusCode: resp.StatusCode, Problem: "token endpoint rejected the credential"}
+	}
+	var result CrunchyrollTokenResponse
+	if err := json.Unmarshal(data, &result); err != nil {
+		return CrunchyrollTokenResponse{}, &TokenError{StatusCode: resp.StatusCode, Problem: "invalid JSON response"}
+	}
+	if strings.TrimSpace(result.AccessToken) == "" {
+		return CrunchyrollTokenResponse{}, &TokenError{StatusCode: resp.StatusCode, Problem: "response has no access token"}
+	}
+	if strings.TrimSpace(result.AccountID) == "" {
+		return CrunchyrollTokenResponse{}, &TokenError{StatusCode: resp.StatusCode, Problem: "response has no account identity"}
+	}
+	return result, nil
+}
 
-	return result.AccessToken
+func refreshAccessToken() error {
+	authState.Lock()
+	defer authState.Unlock()
+	if authState.etpRT == "" {
+		return &TokenError{Problem: "credential is not configured"}
+	}
+	result, err := GetAccessToken(authState.etpRT)
+	if err != nil {
+		return err
+	}
+	if authState.accountID != "" && authState.accountID != result.AccountID {
+		return &AccountIdentityMismatchError{Expected: authState.accountID, Actual: result.AccountID}
+	}
+	if authState.accountID == "" {
+		authState.accountID = result.AccountID
+	}
+	token = result.AccessToken
+	return nil
 }

--- a/token_test.go
+++ b/token_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetAccessTokenRejectsMissingAccountIdentity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"token"}`))
+	}))
+	defer server.Close()
+	oldEndpoint := tokenEndpoint
+	tokenEndpoint = server.URL
+	defer func() { tokenEndpoint = oldEndpoint }()
+	_, err := GetAccessToken("cookie")
+	var tokenErr *TokenError
+	if !errors.As(err, &tokenErr) || tokenErr.Problem != "response has no account identity" {
+		t.Fatalf("expected missing-identity TokenError, got %v", err)
+	}
+}
+
+func TestRefreshAccessTokenRejectsDifferentAccountBeforeAdoptingToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"new-token","account_id":"other-account"}`))
+	}))
+	defer server.Close()
+	oldEndpoint, oldToken := tokenEndpoint, token
+	tokenEndpoint, token = server.URL, "old-token"
+	authState.Lock()
+	oldSecret, oldAccountID := authState.etpRT, authState.accountID
+	authState.etpRT, authState.accountID = "cookie", "expected-account"
+	authState.Unlock()
+	defer func() {
+		tokenEndpoint, token = oldEndpoint, oldToken
+		authState.Lock()
+		authState.etpRT, authState.accountID = oldSecret, oldAccountID
+		authState.Unlock()
+	}()
+	err := refreshAccessToken()
+	var mismatch *AccountIdentityMismatchError
+	if !errors.As(err, &mismatch) || token != "old-token" {
+		t.Fatalf("expected identity mismatch without token adoption, got err=%v token=%q", err, token)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve newest-first bounded traversal, hash-verified cache reuse, atomic checkpoints, exact call accounting, and the global circuit
- classify provider playback code 4294 neutrally unless direct HTTP/header evidence establishes rate limiting
- add versioned ASS cue-quality telemetry and snapshot-aware sparse terminal rechecks while keeping subtitle indexing CDM-free and credentials file-only

## Verification
- go test -count=1 ./...
- go test -race -count=1 ./...
- go vet ./...
- git diff --check
- 396/396 cached ASS files present with matching SHA-256

No merge performed.