### PR TITLE
Add custom MP4 decryption key selection

### DIFF
--- a/download.go
+++ b/download.go
@@ -12,7 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	widevine "github.com/iyear/gowidevine"
 	"github.com/unki2aut/go-mpd"
 )
 
@@ -251,8 +250,8 @@ func downloadParts(baseUrl, representationId *string, set *mpd.AdaptationSet) (s
 	}
 	defer file.Close()
 
-	if err = widevine.DecryptMP4Auto(encFile, keys, file); err != nil {
-		return "", fmt.Errorf("widevine.DecryptMP4Auto: %w", err)
+	if err = decryptMP4(initData, encFile, keys, file); err != nil {
+		return "", fmt.Errorf("decryptMP4: %w", err)
 	}
 
 	return filename, nil

--- a/drm.go
+++ b/drm.go
@@ -5,11 +5,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"strings"
 
+	"github.com/Eyevinn/mp4ff/mp4"
 	"github.com/iyear/gowidevine"
 	"github.com/iyear/gowidevine/widevinepb"
 	"github.com/unki2aut/go-mpd"
@@ -143,4 +145,42 @@ func getLicense(psshData, contentId, videoToken string) error {
 	}
 
 	return nil
+}
+
+// decryptMP4 decrypts a fragmented MP4 read from media, choosing the content
+// key whose ID matches the track's KID. gowidevine's DecryptMP4Auto instead
+// uses the first content key in the license, which decrypts to garbage when the
+// license carries a separate key per track.
+//
+// initData is the initialization segment on its own. The KID lives there, so
+// the key can be selected without reading the media.
+func decryptMP4(initData []byte, media io.Reader, licenseKeys []*widevine.Key, output io.Writer) error {
+	init, err := mp4.DecodeFile(bytes.NewReader(initData))
+	if err != nil {
+		return fmt.Errorf("decode MP4 init segment: %w", err)
+	}
+	if init.Init == nil {
+		return errors.New("MP4 has no initialization segment")
+	}
+
+	decryptInfo, err := mp4.DecryptInit(init.Init)
+	if err != nil {
+		return fmt.Errorf("read MP4 encryption info: %w", err)
+	}
+
+	for _, track := range decryptInfo.TrackInfos {
+		if track.Sinf == nil || track.Sinf.Schi == nil || track.Sinf.Schi.Tenc == nil {
+			continue
+		}
+		kid := track.Sinf.Schi.Tenc.DefaultKID
+		// Match this track's KID with a content key returned by the license.
+		for _, key := range licenseKeys {
+			if key.Type == widevinepb.License_KeyContainer_CONTENT && bytes.Equal(key.ID, kid) {
+				return widevine.DecryptMP4(media, key.Key, output)
+			}
+		}
+		return fmt.Errorf("no license key found for MP4 KID %x", kid)
+	}
+
+	return errors.New("MP4 has no encrypted tracks")
 }

--- a/drm.go
+++ b/drm.go
@@ -168,6 +168,7 @@ func decryptMP4(initData []byte, media io.Reader, licenseKeys []*widevine.Key, o
 		return fmt.Errorf("read MP4 encryption info: %w", err)
 	}
 
+	var unmatched []string
 	for _, track := range decryptInfo.TrackInfos {
 		if track.Sinf == nil || track.Sinf.Schi == nil || track.Sinf.Schi.Tenc == nil {
 			continue
@@ -179,8 +180,12 @@ func decryptMP4(initData []byte, media io.Reader, licenseKeys []*widevine.Key, o
 				return widevine.DecryptMP4(media, key.Key, output)
 			}
 		}
-		return fmt.Errorf("no license key found for MP4 KID %x", kid)
+		// Keep looking: a later track may still match a key in the license.
+		unmatched = append(unmatched, fmt.Sprintf("%x", kid))
 	}
 
+	if len(unmatched) > 0 {
+		return fmt.Errorf("no license key found for MP4 KID(s) %s", strings.Join(unmatched, ", "))
+	}
 	return errors.New("MP4 has no encrypted tracks")
 }

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module crunchyroll-downloader
 go 1.25
 
 require (
+	github.com/Eyevinn/mp4ff v0.48.0
 	github.com/google/uuid v1.6.0
 	github.com/iyear/gowidevine v0.1.3
 	github.com/unki2aut/go-mpd v0.0.0-20250515065241-e261b43d6523
 )
 
 require (
-	github.com/Eyevinn/mp4ff v0.48.0 // indirect
 	github.com/chmike/cmac-go v1.1.0 // indirect
 	github.com/unki2aut/go-xsd-types v0.0.0-20200220223938-30e5405398f8 // indirect
 	google.golang.org/protobuf v1.36.2 // indirect


### PR DESCRIPTION
Replace the automatic Widevine MP4 decryption helper with a local `decryptMP4` implementation. The new logic parses the MP4 init segment, extracts each track's KID, matches it against returned Widevine content keys, and decrypts with the correct key while surfacing clearer errors for missing init data, encryption metadata, or license keys.