### PR TITLE
 Add configurable download backoff + retry rate-limited episodes in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Usage of ./crunchyroll-downloader:
         Closed caption language(s), comma-separated for multiple (e.g. "en-US"). Downloaded in addition to --subs-lang, not instead of it
   -debug-manifest
         Log raw episode playback JSON and manifest XML
+  -download-delay duration
+        Minimum delay between episode downloads, to help avoid Crunchyroll's rate limiting (e.g. "30s", "2m")
   -etp-rt string
         The "etp_rt" cookie value of your account
   -file string
@@ -77,6 +79,13 @@ To download multiple audio tracks and subtitles into a single file (the first of
 ```shell
 ./crunchyroll-downloader --url https://www.crunchyroll.com/watch/GE00198973JAJP/dawn-and-confusion --etp-rt replace_this --audio-lang ja-JP,en-US --subs-lang en-US,es-419,de-DE
 ```
+
+If you're getting rate-limited while downloading a season/batch, wait at least this long between each episode:
+```shell
+./crunchyroll-downloader --url https://www.crunchyroll.com/series/GJ0H7Q5ZJ/hells-paradise --season 1 --etp-rt replace_this --download-delay 30s
+```
+
+If Crunchyroll rate-limits an episode anyway, it's retried in place (starting at `-download-delay`, or 1 minute if unset, doubling up to 30 minutes on repeated hits) instead of moving on to the next episode and tripping the same limit again.
 
 ## Building
 

--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// downloadBackoff enforces a minimum gap between the end of one episode
+// download and the start of the next, to help avoid tripping Crunchyroll's
+// rate limiting on accounts that download many episodes in a row. now and
+// sleep are overridable so tests don't have to wait on the real clock.
+type downloadBackoff struct {
+	delay time.Duration
+	now   func() time.Time
+	sleep func(time.Duration)
+
+	mu            sync.Mutex
+	started       bool
+	last          time.Time
+	rateLimitHits int
+}
+
+// defaultRateLimitWait is the starting retry delay for a rate-limited episode
+// when no -download-delay is configured.
+const defaultRateLimitWait = time.Minute
+
+// maxRateLimitWait caps rateLimitWait's exponential growth so a long streak of
+// consecutive rate-limit hits doesn't produce absurd delays.
+const maxRateLimitWait = 30 * time.Minute
+
+func newDownloadBackoff(delay time.Duration) *downloadBackoff {
+	return &downloadBackoff{delay: delay, now: time.Now, sleep: time.Sleep}
+}
+
+// wait blocks until delay has elapsed since the matching done call for the
+// previous download. It is a no-op before the first download, when b is nil,
+// or when no delay is configured.
+func (b *downloadBackoff) wait() {
+	if b == nil || b.delay <= 0 {
+		return
+	}
+
+	b.mu.Lock()
+	if !b.started {
+		b.mu.Unlock()
+		return
+	}
+	remaining := b.delay - b.now().Sub(b.last)
+	b.mu.Unlock()
+
+	if remaining > 0 {
+		fmt.Printf("Waiting %s before the next download (rate-limit backoff)...\n", remaining.Round(time.Second))
+		b.sleep(remaining)
+	}
+}
+
+// done marks a download as finished, starting the clock that the next wait
+// call measures against.
+func (b *downloadBackoff) done() {
+	if b == nil || b.delay <= 0 {
+		return
+	}
+	b.mu.Lock()
+	b.last = b.now()
+	b.started = true
+	b.mu.Unlock()
+}
+
+// rateLimitWait returns how long to wait before retrying an episode that was
+// just rate-limited by Crunchyroll, doubling with each consecutive hit (since
+// the last resetRateLimit) up to maxRateLimitWait. Safe to call on a nil
+// backoff, so it works whether or not -download-delay is configured.
+func (b *downloadBackoff) rateLimitWait() time.Duration {
+	base := defaultRateLimitWait
+	if b != nil && b.delay > base {
+		base = b.delay
+	}
+
+	var hits int
+	if b != nil {
+		b.mu.Lock()
+		hits = b.rateLimitHits
+		b.rateLimitHits++
+		b.mu.Unlock()
+	}
+
+	wait := base
+	for i := 0; i < hits && wait < maxRateLimitWait; i++ {
+		wait *= 2
+	}
+	if wait > maxRateLimitWait {
+		wait = maxRateLimitWait
+	}
+	return wait
+}
+
+// resetRateLimit clears the consecutive-hit counter after a successful
+// download. Safe to call on a nil backoff.
+func (b *downloadBackoff) resetRateLimit() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.rateLimitHits = 0
+	b.mu.Unlock()
+}

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDownloadBackoffFirstWaitIsNoop(t *testing.T) {
+	var slept time.Duration
+	b := newDownloadBackoff(5 * time.Second)
+	b.sleep = func(d time.Duration) { slept = d }
+
+	b.wait()
+	if slept != 0 {
+		t.Fatalf("wait() before any download slept %v, want 0", slept)
+	}
+}
+
+func TestDownloadBackoffWaitsRemainingDelay(t *testing.T) {
+	now := time.Unix(0, 0)
+	var slept time.Duration
+	b := newDownloadBackoff(5 * time.Second)
+	b.now = func() time.Time { return now }
+	b.sleep = func(d time.Duration) { slept = d; now = now.Add(d) }
+
+	b.done()
+	now = now.Add(2 * time.Second) // only 2s of the 5s delay has elapsed
+	b.wait()
+	if slept != 3*time.Second {
+		t.Fatalf("wait() slept %v, want 3s", slept)
+	}
+}
+
+func TestDownloadBackoffSkipsWaitWhenDelayElapsed(t *testing.T) {
+	now := time.Unix(0, 0)
+	var slept time.Duration
+	b := newDownloadBackoff(5 * time.Second)
+	b.now = func() time.Time { return now }
+	b.sleep = func(d time.Duration) { slept = d }
+
+	b.done()
+	now = now.Add(10 * time.Second) // more than the delay has already passed
+	b.wait()
+	if slept != 0 {
+		t.Fatalf("wait() slept %v, want 0 (delay already elapsed)", slept)
+	}
+}
+
+func TestDownloadBackoffDisabledIsNoop(t *testing.T) {
+	var slept time.Duration
+	b := newDownloadBackoff(0)
+	b.sleep = func(d time.Duration) { slept = d }
+
+	b.done()
+	b.wait()
+	if slept != 0 {
+		t.Fatalf("wait() slept %v with delay disabled, want 0", slept)
+	}
+}
+
+func TestDownloadBackoffNilIsNoop(t *testing.T) {
+	var b *downloadBackoff
+	b.done()
+	b.wait() // must not panic
+}
+
+func TestRateLimitWaitGrowsAndCaps(t *testing.T) {
+	b := newDownloadBackoff(0)
+
+	want := []time.Duration{
+		defaultRateLimitWait,
+		2 * defaultRateLimitWait,
+		4 * defaultRateLimitWait,
+	}
+	for i, w := range want {
+		if got := b.rateLimitWait(); got != w {
+			t.Fatalf("hit %d: rateLimitWait() = %v, want %v", i, got, w)
+		}
+	}
+
+	// Keep hitting it until it should be capped.
+	var last time.Duration
+	for i := 0; i < 20; i++ {
+		last = b.rateLimitWait()
+	}
+	if last != maxRateLimitWait {
+		t.Fatalf("rateLimitWait() after many hits = %v, want cap %v", last, maxRateLimitWait)
+	}
+}
+
+func TestRateLimitWaitUsesConfiguredDelayAsFloor(t *testing.T) {
+	b := newDownloadBackoff(5 * time.Minute)
+	if got := b.rateLimitWait(); got != 5*time.Minute {
+		t.Fatalf("rateLimitWait() = %v, want configured delay 5m as the floor", got)
+	}
+}
+
+func TestRateLimitWaitResets(t *testing.T) {
+	b := newDownloadBackoff(0)
+	b.rateLimitWait()
+	b.rateLimitWait()
+	b.resetRateLimit()
+
+	if got := b.rateLimitWait(); got != defaultRateLimitWait {
+		t.Fatalf("rateLimitWait() after reset = %v, want %v", got, defaultRateLimitWait)
+	}
+}
+
+func TestRateLimitWaitNilIsSafe(t *testing.T) {
+	var b *downloadBackoff
+	if got := b.rateLimitWait(); got != defaultRateLimitWait {
+		t.Fatalf("nil backoff rateLimitWait() = %v, want %v", got, defaultRateLimitWait)
+	}
+	b.resetRateLimit() // must not panic
+}

--- a/download.go
+++ b/download.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -385,7 +386,7 @@ func filterAvailableLangs(langs []string, available map[string]*Subtitle, kind s
 	return filtered
 }
 
-func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLangs, ccLangs []string, videoQuality, audioQuality *string) {
+func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLangs, ccLangs []string, videoQuality, audioQuality *string) (err error) {
 	cleanSeriesTitle := sanitizeFilename(info.EpisodeMetadata.SeriesTitle)
 	cleanEpisodeTitle := sanitizeFilename(info.Title)
 
@@ -401,7 +402,7 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 		*videoQuality,
 	))
 
-	if _, err := os.Stat(outputFile); err == nil {
+	if _, statErr := os.Stat(outputFile); statErr == nil {
 		fmt.Printf("Episode %v is already downloaded, skipping...\n", info.EpisodeMetadata.EpisodeNumber)
 		return
 	}
@@ -447,6 +448,11 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 
 	fmt.Printf("Downloading: %s (S%02vE%02v) from %s\n", info.Title, info.EpisodeMetadata.SeasonNumber, info.EpisodeMetadata.EpisodeNumber, info.EpisodeMetadata.SeriesTitle)
 
+	// Space this download out from the previous one, if a delay is configured.
+	// Applied here rather than around the whole function so that episodes
+	// already on disk (returned above) don't burn the wait for nothing.
+	backoff.wait()
+
 	// activeStreams tracks every playback token we open so we can release them
 	// all if anything fails partway through.
 	var (
@@ -454,6 +460,10 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 		activeStreams = map[string]string{}
 	)
 	defer func() {
+		// Start the backoff clock as soon as this download is over, success or
+		// not, so a failed/rate-limited attempt doesn't get retried immediately.
+		backoff.done()
+
 		print("Cleaning up...\n")
 
 		streamsMu.Lock()
@@ -467,7 +477,16 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 			}
 		}
 		if r := recover(); r != nil {
-			fmt.Printf("Recovered from error: %v\n%s\n", r, runtimedebug.Stack())
+			if e, ok := r.(error); ok {
+				err = e
+			} else {
+				err = fmt.Errorf("%v", r)
+			}
+			if *debug {
+				fmt.Printf("Recovered from error: %v\n%s\n", r, runtimedebug.Stack())
+			} else {
+				fmt.Printf("Recovered from error: %v\n", r)
+			}
 		}
 	}()
 
@@ -658,6 +677,29 @@ func downloadEpisode(baseContentId string, info EpisodeInfo, audioLangs, subsLan
 	}
 
 	mergeEverything(videoFile, audioTracks, subTracks, outputFile, info)
+	return nil
+}
+
+// downloadEpisodeWithRetry runs downloadEpisode, retrying the same episode
+// with a growing delay whenever Crunchyroll rate-limits the account, instead
+// of moving on to the next episode and immediately tripping the same rate
+// limit again.
+func downloadEpisodeWithRetry(baseContentId string, info EpisodeInfo, audioLangs, subsLangs, ccLangs []string, videoQuality, audioQuality *string) {
+	for {
+		err := downloadEpisode(baseContentId, info, audioLangs, subsLangs, ccLangs, videoQuality, audioQuality)
+		if err == nil {
+			backoff.resetRateLimit()
+			return
+		}
+		if !errors.Is(err, ErrRateLimited) {
+			return
+		}
+
+		wait := backoff.rateLimitWait()
+		retryAt := time.Now().Add(wait)
+		fmt.Printf("Retrying this episode in %s [%s]...\n", wait.Round(time.Second), retryAt.Local().Format(time.Kitchen))
+		time.Sleep(wait)
+	}
 }
 
 func downloadSeason(videoQuality, audioQuality *string, audioLangs, subsLangs, ccLangs []string, episodes []SeasonEpisode) {
@@ -676,6 +718,6 @@ func downloadSeason(videoQuality, audioQuality *string, audioLangs, subsLangs, c
 			Title: episode.Title,
 		}
 
-		downloadEpisode(episode.ID, info, audioLangs, subsLangs, ccLangs, videoQuality, audioQuality)
+		downloadEpisodeWithRetry(episode.ID, info, audioLangs, subsLangs, ccLangs, videoQuality, audioQuality)
 	}
 }

--- a/episode.go
+++ b/episode.go
@@ -2,11 +2,17 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 )
+
+// ErrRateLimited marks a playback error caused by Crunchyroll's 429-class rate
+// limiting, so callers can retry the same episode instead of treating it like
+// any other playback failure and moving on.
+var ErrRateLimited = errors.New("rate limited by Crunchyroll")
 
 // EpisodeError is the playback endpoint's polymorphic "error" field. It is a
 // string message on failure, but Crunchyroll also returns false, null or a bare
@@ -87,6 +93,7 @@ func getEpisode(id string) (Episode, error) {
 		fmt.Println()
 		if strings.HasPrefix(string(episode.Error), "429") {
 			fmt.Println("Crunchyroll is rate-limiting this account. Wait a while before retrying, or use a different account.")
+			return Episode{}, fmt.Errorf("playback error: %s: %w", episode.Error, ErrRateLimited)
 		}
 		return Episode{}, fmt.Errorf("playback error: %s", episode.Error)
 	}

--- a/main.go
+++ b/main.go
@@ -18,7 +18,13 @@ var (
 	seasonNumber  = flag.Int("season", 0, "Season number. Not used if an episode link is entered")
 	etpRt         = flag.String("etp-rt", "", "The \"etp_rt\" cookie value of your account")
 	debug         = flag.Bool("debug-manifest", false, "Log raw episode playback JSON and manifest XML")
+	downloadDelay = flag.Duration("download-delay", 0, "Minimum delay between episode downloads, to help avoid Crunchyroll's rate limiting (e.g. \"30s\", \"2m\")")
 )
+
+// backoff spaces out consecutive episode downloads by *downloadDelay. It is
+// initialized in main() once flags are parsed, and is a no-op (including when
+// left nil) whenever no delay is configured.
+var backoff *downloadBackoff
 
 // parseLangs splits a comma-separated locale list, trimming spaces and dropping
 // empties.
@@ -70,7 +76,7 @@ func processUrl(url string) {
 
 	if contentType == "watch" {
 		info := getEpisodeInfo(contentId)
-		downloadEpisode(contentId, info, audioLangs, subsLangs, ccLangs, videoQuality, audioQuality)
+		downloadEpisodeWithRetry(contentId, info, audioLangs, subsLangs, ccLangs, videoQuality, audioQuality)
 	} else {
 		seasons := getSeasons(contentId, primaryAudio, primarySubs)
 
@@ -116,6 +122,7 @@ func main() {
 	}
 
 	token = GetAccessToken(*etpRt)
+	backoff = newDownloadBackoff(*downloadDelay)
 
 	if *urlsFile != "" {
 		file, err := os.Open(*urlsFile)


### PR DESCRIPTION
- Adds a -download-delay flag that enforces a minimum gap between episode downloads, to help avoid tripping Crunchyroll's rate limiting on batch/season downloads.
- When Crunchyroll does rate-limit an episode, the same episode is now retried in place with an exponentially growing wait (starting at -download-delay or 1 minute, doubling up to a 30-minute cap) instead of moving on to the next episode and immediately re-tripping the same limit.
- downloadEpisode now returns an error instead of only logging/recovering internally, and a new ErrRateLimited sentinel lets callers distinguish rate-limit failures from other playback errors.

Details
- backoff.go (new): downloadBackoff type tracking last-download time and consecutive rate-limit hits; overridable clock/sleep for testability.
- download.go: downloadEpisodeWithRetry wraps downloadEpisode, looping on ErrRateLimited; downloadSeason now calls the retrying variant.
- episode.go: wraps 429 responses in ErrRateLimited.
- main.go: wires up the -download-delay flag and global backoff instance.
- backoff_test.go (new): unit tests for delay/retry behavior.
- README updated with flag docs and a batch-download example.

Testing
- backoff_test.go covers wait/done timing and exponential rate-limit backoff.